### PR TITLE
Add 105 .NET and Aspire skills to catalog

### DIFF
--- a/catalog/dotnet/analyzing-dotnet-performance.json
+++ b/catalog/dotnet/analyzing-dotnet-performance.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:analyzing-dotnet-performance",
+  "displayName": "Analyzing Dotnet Performance",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md",
+  "description": "Scans .NET code for ~50 performance anti-patterns across async, memory, strings, collections, LINQ, regex, serialization, and I/O with tiered...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/analyzing-dotnet-performance/SKILL.md"
+  }
+}

--- a/catalog/dotnet/android-tombstone-symbolication.json
+++ b/catalog/dotnet/android-tombstone-symbolication.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:android-tombstone-symbolication",
+  "displayName": "Android Tombstone Symbolication",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/android-tombstone-symbolication/SKILL.md",
+  "description": "Symbolicate the .NET runtime frames in an Android tombstone file.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/android-tombstone-symbolication/SKILL.md"
+  }
+}

--- a/catalog/dotnet/apple-crash-symbolication.json
+++ b/catalog/dotnet/apple-crash-symbolication.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:apple-crash-symbolication",
+  "displayName": "Apple Crash Symbolication",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/apple-crash-symbolication/SKILL.md",
+  "description": "Symbolicate .NET runtime frames in Apple platform .ips crash logs (iOS, tvOS, Mac Catalyst, macOS).",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/apple-crash-symbolication/SKILL.md"
+  }
+}

--- a/catalog/dotnet/assertion-quality.json
+++ b/catalog/dotnet/assertion-quality.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:assertion-quality",
+  "displayName": "Assertion Quality",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/assertion-quality/SKILL.md",
+  "description": "Analyzes the variety and depth of assertions across test suites in any language.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/assertion-quality/SKILL.md"
+  }
+}

--- a/catalog/dotnet/author-component.json
+++ b/catalog/dotnet/author-component.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:author-component",
+  "displayName": "Author Component",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/author-component/SKILL.md",
+  "description": "Create or review Blazor components (.razor files) with correct architecture.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/author-component/SKILL.md"
+  }
+}

--- a/catalog/dotnet/binlog-failure-analysis.json
+++ b/catalog/dotnet/binlog-failure-analysis.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:binlog-failure-analysis",
+  "displayName": "Binlog Failure Analysis",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md",
+  "description": "Analyze MSBuild binary logs to diagnose build failures.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/binlog-failure-analysis/SKILL.md"
+  }
+}

--- a/catalog/dotnet/binlog-generation.json
+++ b/catalog/dotnet/binlog-generation.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:binlog-generation",
+  "displayName": "Binlog Generation",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/binlog-generation/SKILL.md",
+  "description": "Generate MSBuild binary logs (binlogs) for build diagnostics and analysis.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/binlog-generation/SKILL.md"
+  }
+}

--- a/catalog/dotnet/build-parallelism.json
+++ b/catalog/dotnet/build-parallelism.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:build-parallelism",
+  "displayName": "Build Parallelism",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/build-parallelism/SKILL.md",
+  "description": "Guide for optimizing MSBuild build parallelism and multi-project scheduling.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/build-parallelism/SKILL.md"
+  }
+}

--- a/catalog/dotnet/build-perf-baseline.json
+++ b/catalog/dotnet/build-perf-baseline.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:build-perf-baseline",
+  "displayName": "Build Perf Baseline",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/build-perf-baseline/SKILL.md",
+  "description": "Establish build performance baselines and apply systematic optimization techniques.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/build-perf-baseline/SKILL.md"
+  }
+}

--- a/catalog/dotnet/build-perf-diagnostics.json
+++ b/catalog/dotnet/build-perf-diagnostics.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:build-perf-diagnostics",
+  "displayName": "Build Perf Diagnostics",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/build-perf-diagnostics/SKILL.md",
+  "description": "Diagnose MSBuild build performance bottlenecks using binary log analysis.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/build-perf-diagnostics/SKILL.md"
+  }
+}

--- a/catalog/dotnet/check-bin-obj-clash.json
+++ b/catalog/dotnet/check-bin-obj-clash.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:check-bin-obj-clash",
+  "displayName": "Check Bin Obj Clash",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md",
+  "description": "Detects MSBuild projects with conflicting OutputPath or IntermediateOutputPath.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/check-bin-obj-clash/SKILL.md"
+  }
+}

--- a/catalog/dotnet/clr-activation-debugging.json
+++ b/catalog/dotnet/clr-activation-debugging.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:clr-activation-debugging",
+  "displayName": "Clr Activation Debugging",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/clr-activation-debugging/SKILL.md",
+  "description": "Diagnoses .NET Framework CLR activation issues using CLR activation logs (CLRLoad logs) produced by mscoree.dll.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/clr-activation-debugging/SKILL.md"
+  }
+}

--- a/catalog/dotnet/code-testing-agent.json
+++ b/catalog/dotnet/code-testing-agent.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:code-testing-agent",
+  "displayName": "Code Testing Agent",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/code-testing-agent/SKILL.md",
+  "description": "Generates and writes new unit tests for any programming language - scaffolds .NET test projects, pytest suites, Vitest/Jest suites, Go test files...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/code-testing-agent/SKILL.md"
+  }
+}

--- a/catalog/dotnet/code-testing-extensions.json
+++ b/catalog/dotnet/code-testing-extensions.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:code-testing-extensions",
+  "displayName": "Code Testing Extensions",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/code-testing-extensions/SKILL.md",
+  "description": "Provides file paths to language-specific extension files for the code-testing pipeline.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/code-testing-extensions/SKILL.md"
+  }
+}

--- a/catalog/dotnet/collect-user-input.json
+++ b/catalog/dotnet/collect-user-input.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:collect-user-input",
+  "displayName": "Collect User Input",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/collect-user-input/SKILL.md",
+  "description": "Build forms, validate data, and react to user input in Blazor.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/collect-user-input/SKILL.md"
+  }
+}

--- a/catalog/dotnet/configure-auth.json
+++ b/catalog/dotnet/configure-auth.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:configure-auth",
+  "displayName": "Configure Auth",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/configure-auth/SKILL.md",
+  "description": "Add authentication and authorization to a Blazor Web App, accounting for the app's render mode.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/configure-auth/SKILL.md"
+  }
+}

--- a/catalog/dotnet/configuring-opentelemetry-dotnet.json
+++ b/catalog/dotnet/configuring-opentelemetry-dotnet.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:configuring-opentelemetry-dotnet",
+  "displayName": "Configuring Opentelemetry Dotnet",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-aspnetcore/skills/configuring-opentelemetry-dotnet/SKILL.md",
+  "description": "Configure OpenTelemetry distributed tracing, metrics, and logging in ASP.NET Core using the .NET OpenTelemetry SDK.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-aspnetcore/skills/configuring-opentelemetry-dotnet/SKILL.md"
+  }
+}

--- a/catalog/dotnet/convert-blazor-server-to-webapp.json
+++ b/catalog/dotnet/convert-blazor-server-to-webapp.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:convert-blazor-server-to-webapp",
+  "displayName": "Convert Blazor Server To Webapp",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-aspnetcore/skills/convert-blazor-server-to-webapp/SKILL.md",
+  "description": "Guides conversion of a pre-.NET 8 Blazor Server app into a .NET 8+ Blazor Web App.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-aspnetcore/skills/convert-blazor-server-to-webapp/SKILL.md"
+  }
+}

--- a/catalog/dotnet/convert-to-cpm.json
+++ b/catalog/dotnet/convert-to-cpm.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:convert-to-cpm",
+  "displayName": "Convert To Cpm",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md",
+  "description": "Convert .NET projects and solutions (.sln, .slnx) to NuGet Central Package Management (CPM) using Directory.Packages.props.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-nuget/skills/convert-to-cpm/SKILL.md"
+  }
+}

--- a/catalog/dotnet/coordinate-components.json
+++ b/catalog/dotnet/coordinate-components.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:coordinate-components",
+  "displayName": "Coordinate Components",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/coordinate-components/SKILL.md",
+  "description": "Share state between components that don't have a direct parent-child parameter relationship, using cascading values, scoped services with change...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/coordinate-components/SKILL.md"
+  }
+}

--- a/catalog/dotnet/coverage-analysis.json
+++ b/catalog/dotnet/coverage-analysis.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:coverage-analysis",
+  "displayName": "Coverage Analysis",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/coverage-analysis/SKILL.md",
+  "description": "Project-wide code coverage and CRAP (Change Risk Anti-Patterns) score analysis for .NET projects.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/coverage-analysis/SKILL.md"
+  }
+}

--- a/catalog/dotnet/crap-score.json
+++ b/catalog/dotnet/crap-score.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:crap-score",
+  "displayName": "Crap Score",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/crap-score/SKILL.md",
+  "description": "Calculates targeted CRAP (Change Risk Anti-Patterns) scores for a named .NET method, class, or single source file.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/crap-score/SKILL.md"
+  }
+}

--- a/catalog/dotnet/create-blazor-project.json
+++ b/catalog/dotnet/create-blazor-project.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:create-blazor-project",
+  "displayName": "Create Blazor Project",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/create-blazor-project/SKILL.md",
+  "description": "Create a new ASP.NET Core web application or web site using Blazor.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/create-blazor-project/SKILL.md"
+  }
+}

--- a/catalog/dotnet/csharp-scripts.json
+++ b/catalog/dotnet/csharp-scripts.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:csharp-scripts",
+  "displayName": "Csharp Scripts",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet/skills/csharp-scripts/SKILL.md",
+  "description": "Run file-based C# apps with the .NET CLI when the user explicitly wants C#/.NET code without creating a project.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet/skills/csharp-scripts/SKILL.md"
+  }
+}

--- a/catalog/dotnet/detect-static-dependencies.json
+++ b/catalog/dotnet/detect-static-dependencies.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:detect-static-dependencies",
+  "displayName": "Detect Static Dependencies",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md",
+  "description": "Scan C# source files for hard-to-test static dependencies - DateTime.Now/UtcNow, File.*, Directory.*, Environment.*, HttpClient, Console.*...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/detect-static-dependencies/SKILL.md"
+  }
+}

--- a/catalog/dotnet/directory-build-organization.json
+++ b/catalog/dotnet/directory-build-organization.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:directory-build-organization",
+  "displayName": "Directory Build Organization",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/directory-build-organization/SKILL.md",
+  "description": "Guide for organizing MSBuild infrastructure with Directory.Build.props, Directory.Build.targets, Directory.Packages.props, and Directory.Build.rsp.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/directory-build-organization/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-aot-compat.json
+++ b/catalog/dotnet/dotnet-aot-compat.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-aot-compat",
+  "displayName": "Dotnet Aot Compat",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/dotnet-aot-compat/SKILL.md",
+  "description": "Make .NET projects compatible with Native AOT and trimming by systematically resolving IL trim/AOT analyzer warnings.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/dotnet-aot-compat/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-maui-doctor.json
+++ b/catalog/dotnet/dotnet-maui-doctor.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-maui-doctor",
+  "displayName": "Dotnet Maui Doctor",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/dotnet-maui-doctor/SKILL.md",
+  "description": "Diagnoses and fixes .NET MAUI development environment issues.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/dotnet-maui-doctor/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-pinvoke.json
+++ b/catalog/dotnet/dotnet-pinvoke.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-pinvoke",
+  "displayName": "Dotnet Pinvoke",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet/skills/dotnet-pinvoke/SKILL.md",
+  "description": "Correctly call native (C/C++) libraries from .NET using P/Invoke and LibraryImport.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet/skills/dotnet-pinvoke/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-test-frameworks.json
+++ b/catalog/dotnet/dotnet-test-frameworks.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-test-frameworks",
+  "displayName": "Dotnet Test Frameworks",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/dotnet-test-frameworks/SKILL.md",
+  "description": "Reference data for .NET test framework detection patterns, assertion APIs, skip annotations, setup/teardown methods, and common test smell indicators...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/dotnet-test-frameworks/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-trace-collect.json
+++ b/catalog/dotnet/dotnet-trace-collect.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-trace-collect",
+  "displayName": "Dotnet Trace Collect",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/dotnet-trace-collect/SKILL.md",
+  "description": "Guide developers through capturing diagnostic artifacts to diagnose production .NET performance issues.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/dotnet-trace-collect/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dotnet-webapi.json
+++ b/catalog/dotnet/dotnet-webapi.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dotnet-webapi",
+  "displayName": "Dotnet Webapi",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-aspnetcore/skills/dotnet-webapi/SKILL.md",
+  "description": "Guides creation and modification of ASP.NET Core Web API endpoints with correct HTTP semantics, OpenAPI metadata, and error handling.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-aspnetcore/skills/dotnet-webapi/SKILL.md"
+  }
+}

--- a/catalog/dotnet/dump-collect.json
+++ b/catalog/dotnet/dump-collect.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:dump-collect",
+  "displayName": "Dump Collect",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/dump-collect/SKILL.md",
+  "description": "Configure and collect crash dumps for modern .NET applications.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/dump-collect/SKILL.md"
+  }
+}

--- a/catalog/dotnet/eval-performance.json
+++ b/catalog/dotnet/eval-performance.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:eval-performance",
+  "displayName": "Eval Performance",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/eval-performance/SKILL.md",
+  "description": "Guide for diagnosing and improving MSBuild project evaluation performance.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/eval-performance/SKILL.md"
+  }
+}

--- a/catalog/dotnet/exp-mock-usage-analysis.json
+++ b/catalog/dotnet/exp-mock-usage-analysis.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:exp-mock-usage-analysis",
+  "displayName": "Exp Mock Usage Analysis",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-experimental/skills/exp-mock-usage-analysis/SKILL.md",
+  "description": "Audits .NET test mock usage by tracing each mock setup through the production code's execution path to find dead, unreachable, redundant, or...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-experimental/skills/exp-mock-usage-analysis/SKILL.md"
+  }
+}

--- a/catalog/dotnet/exp-simd-vectorization.json
+++ b/catalog/dotnet/exp-simd-vectorization.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:exp-simd-vectorization",
+  "displayName": "Exp Simd Vectorization",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-experimental/skills/exp-simd-vectorization/SKILL.md",
+  "description": "Optimizes hot-path scalar loops in .NET 8+ with cross-platform Vector128/Vector256/Vector512 SIMD intrinsics, or replaces manual math loops with...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-experimental/skills/exp-simd-vectorization/SKILL.md"
+  }
+}

--- a/catalog/dotnet/exp-test-maintainability.json
+++ b/catalog/dotnet/exp-test-maintainability.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:exp-test-maintainability",
+  "displayName": "Exp Test Maintainability",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-experimental/skills/exp-test-maintainability/SKILL.md",
+  "description": "Detects duplicate boilerplate, copy-paste tests, and structural maintainability issues across .NET test suites.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-experimental/skills/exp-test-maintainability/SKILL.md"
+  }
+}

--- a/catalog/dotnet/extension-points.json
+++ b/catalog/dotnet/extension-points.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:extension-points",
+  "displayName": "Extension Points",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/extension-points/SKILL.md",
+  "description": "Guide for MSBuild extensibility: CustomBefore/CustomAfter hooks, wildcard imports with alphabetic ordering, import gating with control properties...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/extension-points/SKILL.md"
+  }
+}

--- a/catalog/dotnet/fetch-and-send-data.json
+++ b/catalog/dotnet/fetch-and-send-data.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:fetch-and-send-data",
+  "displayName": "Fetch And Send Data",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/fetch-and-send-data/SKILL.md",
+  "description": "Call APIs, load data into components, and handle the async lifecycle in Blazor.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/fetch-and-send-data/SKILL.md"
+  }
+}

--- a/catalog/dotnet/filter-syntax.json
+++ b/catalog/dotnet/filter-syntax.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:filter-syntax",
+  "displayName": "Filter Syntax",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/filter-syntax/SKILL.md",
+  "description": "Reference data for test filter syntax across all platform and framework combinations: VSTest --filter expressions, MTP filters for MSTest/NUnit/xUnit...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/filter-syntax/SKILL.md"
+  }
+}

--- a/catalog/dotnet/find-untested-sources-polyglot.json
+++ b/catalog/dotnet/find-untested-sources-polyglot.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:find-untested-sources-polyglot",
+  "displayName": "Find Untested Sources Polyglot",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md",
+  "description": "Polyglot, parse-only static analysis that pairs source files with referencing tests across Python, TypeScript/JavaScript, Go, Java, Rust, C#, and...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/find-untested-sources-polyglot/SKILL.md"
+  }
+}

--- a/catalog/dotnet/find-untested-sources.json
+++ b/catalog/dotnet/find-untested-sources.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:find-untested-sources",
+  "displayName": "Find Untested Sources",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/find-untested-sources/SKILL.md",
+  "description": "Parse-only C# analysis that pairs source files with referencing tests and emits JSON: `source_to_tests`, `untested` ordered by declaration count, and...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/find-untested-sources/SKILL.md"
+  }
+}

--- a/catalog/dotnet/generate-testability-wrappers.json
+++ b/catalog/dotnet/generate-testability-wrappers.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:generate-testability-wrappers",
+  "displayName": "Generate Testability Wrappers",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md",
+  "description": "Generate wrapper interfaces and DI registration for hard-to-test static dependencies in C#.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/generate-testability-wrappers/SKILL.md"
+  }
+}

--- a/catalog/dotnet/grade-tests.json
+++ b/catalog/dotnet/grade-tests.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:grade-tests",
+  "displayName": "Grade Tests",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/grade-tests/SKILL.md",
+  "description": "Grades a specified set of test methods individually and produces a concise table mapping each test (fully-qualified name) to a letter grade (A-F), a...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/grade-tests/SKILL.md"
+  }
+}

--- a/catalog/dotnet/including-generated-files.json
+++ b/catalog/dotnet/including-generated-files.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:including-generated-files",
+  "displayName": "Including Generated Files",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/including-generated-files/SKILL.md",
+  "description": "Fix MSBuild targets that generate files during the build but those files are missing from compilation or output.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/including-generated-files/SKILL.md"
+  }
+}

--- a/catalog/dotnet/incremental-build.json
+++ b/catalog/dotnet/incremental-build.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:incremental-build",
+  "displayName": "Incremental Build",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/incremental-build/SKILL.md",
+  "description": "Guide for optimizing MSBuild incremental builds.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/incremental-build/SKILL.md"
+  }
+}

--- a/catalog/dotnet/item-management.json
+++ b/catalog/dotnet/item-management.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:item-management",
+  "displayName": "Item Management",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/item-management/SKILL.md",
+  "description": "Patterns for managing MSBuild item groups: Include/Remove/Update semantics, item metadata, batching with %(Metadata), transforms, per-item filtering...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/item-management/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-app-lifecycle.json
+++ b/catalog/dotnet/maui-app-lifecycle.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-app-lifecycle",
+  "displayName": "Maui App Lifecycle",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-app-lifecycle/SKILL.md",
+  "description": ".NET MAUI app lifecycle guidance - the four app states, cross-platform Window lifecycle events (Created, Activated, Deactivated, Stopped, Resumed...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-app-lifecycle/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-collectionview.json
+++ b/catalog/dotnet/maui-collectionview.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-collectionview",
+  "displayName": "Maui Collectionview",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-collectionview/SKILL.md",
+  "description": "Guidance for implementing CollectionView in .NET MAUI apps - data display, layouts (list & grid), selection, grouping, scrolling, empty views...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-collectionview/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-data-binding.json
+++ b/catalog/dotnet/maui-data-binding.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-data-binding",
+  "displayName": "Maui Data Binding",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-data-binding/SKILL.md",
+  "description": "Guidance for .NET MAUI XAML and C# data bindings - compiled bindings, INotifyPropertyChanged / ObservableObject, value converters, binding modes...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-data-binding/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-dependency-injection.json
+++ b/catalog/dotnet/maui-dependency-injection.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-dependency-injection",
+  "displayName": "Maui Dependency Injection",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-dependency-injection/SKILL.md",
+  "description": "Guidance for configuring dependency injection in .NET MAUI apps - service registration in MauiProgram.cs, lifetime selection (Singleton / Transient /...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-dependency-injection/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-safe-area.json
+++ b/catalog/dotnet/maui-safe-area.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-safe-area",
+  "displayName": "Maui Safe Area",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-safe-area/SKILL.md",
+  "description": ".NET MAUI safe area and edge-to-edge layout guidance for .NET 10+.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-safe-area/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-shell-navigation.json
+++ b/catalog/dotnet/maui-shell-navigation.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-shell-navigation",
+  "displayName": "Maui Shell Navigation",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-shell-navigation/SKILL.md",
+  "description": "Guide for implementing Shell-based navigation in .NET MAUI apps.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-shell-navigation/SKILL.md"
+  }
+}

--- a/catalog/dotnet/maui-theming.json
+++ b/catalog/dotnet/maui-theming.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:maui-theming",
+  "displayName": "Maui Theming",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-maui/skills/maui-theming/SKILL.md",
+  "description": "Guide for theming .NET MAUI apps - light/dark mode via AppThemeBinding, ResourceDictionary theme switching, DynamicResource bindings, system theme...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-maui/skills/maui-theming/SKILL.md"
+  }
+}

--- a/catalog/dotnet/mcp-csharp-create.json
+++ b/catalog/dotnet/mcp-csharp-create.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:mcp-csharp-create",
+  "displayName": "Mcp Csharp Create",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md",
+  "description": "Create MCP servers using the C# SDK and .NET project templates.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-ai/skills/mcp-csharp-create/SKILL.md"
+  }
+}

--- a/catalog/dotnet/mcp-csharp-debug.json
+++ b/catalog/dotnet/mcp-csharp-debug.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:mcp-csharp-debug",
+  "displayName": "Mcp Csharp Debug",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-ai/skills/mcp-csharp-debug/SKILL.md",
+  "description": "Run and debug C# MCP servers locally.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-ai/skills/mcp-csharp-debug/SKILL.md"
+  }
+}

--- a/catalog/dotnet/mcp-csharp-publish.json
+++ b/catalog/dotnet/mcp-csharp-publish.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:mcp-csharp-publish",
+  "displayName": "Mcp Csharp Publish",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-ai/skills/mcp-csharp-publish/SKILL.md",
+  "description": "Publish and deploy C# MCP servers.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-ai/skills/mcp-csharp-publish/SKILL.md"
+  }
+}

--- a/catalog/dotnet/mcp-csharp-test.json
+++ b/catalog/dotnet/mcp-csharp-test.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:mcp-csharp-test",
+  "displayName": "Mcp Csharp Test",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-ai/skills/mcp-csharp-test/SKILL.md",
+  "description": "Test C# MCP servers at multiple levels: unit tests for individual tools and integration tests using the MCP client SDK.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-ai/skills/mcp-csharp-test/SKILL.md"
+  }
+}

--- a/catalog/dotnet/microbenchmarking.json
+++ b/catalog/dotnet/microbenchmarking.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:microbenchmarking",
+  "displayName": "Microbenchmarking",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-diag/skills/microbenchmarking/SKILL.md",
+  "description": "Activate this skill when BenchmarkDotNet (BDN) is involved in the task - creating, running, configuring, or reviewing BDN benchmarks.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-diag/skills/microbenchmarking/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-dotnet10-to-dotnet11.json
+++ b/catalog/dotnet/migrate-dotnet10-to-dotnet11.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-dotnet10-to-dotnet11",
+  "displayName": "Migrate Dotnet10 To Dotnet11",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/SKILL.md",
+  "description": "Migrate a .NET 10 project or solution to .NET 11 and resolve all breaking changes.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/migrate-dotnet10-to-dotnet11/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-dotnet8-to-dotnet9.json
+++ b/catalog/dotnet/migrate-dotnet8-to-dotnet9.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-dotnet8-to-dotnet9",
+  "displayName": "Migrate Dotnet8 To Dotnet9",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/migrate-dotnet8-to-dotnet9/SKILL.md",
+  "description": "Migrate a .NET 8 project to .NET 9 and resolve all breaking changes.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/migrate-dotnet8-to-dotnet9/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-dotnet9-to-dotnet10.json
+++ b/catalog/dotnet/migrate-dotnet9-to-dotnet10.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-dotnet9-to-dotnet10",
+  "displayName": "Migrate Dotnet9 To Dotnet10",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/migrate-dotnet9-to-dotnet10/SKILL.md",
+  "description": "Migrate a .NET 9 project or solution to .NET 10 and resolve all breaking changes.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/migrate-dotnet9-to-dotnet10/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-mstest-v1v2-to-v3.json
+++ b/catalog/dotnet/migrate-mstest-v1v2-to-v3.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-mstest-v1v2-to-v3",
+  "displayName": "Migrate Mstest V1V2 To V3",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-mstest-v1v2-to-v3/SKILL.md",
+  "description": "Migrate MSTest v1 or v2 test project to MSTest v3.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-mstest-v1v2-to-v3/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-mstest-v3-to-v4.json
+++ b/catalog/dotnet/migrate-mstest-v3-to-v4.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-mstest-v3-to-v4",
+  "displayName": "Migrate Mstest V3 To V4",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-mstest-v3-to-v4/SKILL.md",
+  "description": "Fix build errors and breaking changes after upgrading MSTest from v3 to v4, or plan a complete MSTest v3-to-v4 migration.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-mstest-v3-to-v4/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-nullable-references.json
+++ b/catalog/dotnet/migrate-nullable-references.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-nullable-references",
+  "displayName": "Migrate Nullable References",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/migrate-nullable-references/SKILL.md",
+  "description": "Enable nullable reference types in a C# project and systematically resolve all warnings.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/migrate-nullable-references/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-static-to-wrapper.json
+++ b/catalog/dotnet/migrate-static-to-wrapper.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-static-to-wrapper",
+  "displayName": "Migrate Static To Wrapper",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md",
+  "description": "Mechanically replace static dependency call sites with wrapper or built-in abstraction calls across a bounded scope (file, project, or namespace).",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-static-to-wrapper/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-vstest-to-mtp.json
+++ b/catalog/dotnet/migrate-vstest-to-mtp.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-vstest-to-mtp",
+  "displayName": "Migrate Vstest To Mtp",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-vstest-to-mtp/SKILL.md",
+  "description": "Migrates .NET test projects from VSTest to Microsoft.Testing.Platform (MTP).",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-vstest-to-mtp/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-xunit-to-mstest.json
+++ b/catalog/dotnet/migrate-xunit-to-mstest.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-xunit-to-mstest",
+  "displayName": "Migrate Xunit To Mstest",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md",
+  "description": "Migrate .NET test projects from xUnit.net (v2 or v3) to MSTest v4.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-xunit-to-mstest/SKILL.md"
+  }
+}

--- a/catalog/dotnet/migrate-xunit-to-xunit-v3.json
+++ b/catalog/dotnet/migrate-xunit-to-xunit-v3.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:migrate-xunit-to-xunit-v3",
+  "displayName": "Migrate Xunit To Xunit V3",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/migrate-xunit-to-xunit-v3/SKILL.md",
+  "description": "Migrates .NET test projects from xUnit.net v2 to xUnit.net v3.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/migrate-xunit-to-xunit-v3/SKILL.md"
+  }
+}

--- a/catalog/dotnet/minimal-api-file-upload.json
+++ b/catalog/dotnet/minimal-api-file-upload.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:minimal-api-file-upload",
+  "displayName": "Minimal Api File Upload",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-aspnetcore/skills/minimal-api-file-upload/SKILL.md",
+  "description": "File upload endpoints in ASP.NET minimal APIs (.NET 8+)",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-aspnetcore/skills/minimal-api-file-upload/SKILL.md"
+  }
+}

--- a/catalog/dotnet/msbuild-antipatterns.json
+++ b/catalog/dotnet/msbuild-antipatterns.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:msbuild-antipatterns",
+  "displayName": "Msbuild Antipatterns",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md",
+  "description": "Catalog of MSBuild anti-patterns with detection rules and fix recipes.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/msbuild-antipatterns/SKILL.md"
+  }
+}

--- a/catalog/dotnet/msbuild-modernization.json
+++ b/catalog/dotnet/msbuild-modernization.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:msbuild-modernization",
+  "displayName": "Msbuild Modernization",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/msbuild-modernization/SKILL.md",
+  "description": "Guide for modernizing and migrating MSBuild project files to SDK-style format.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/msbuild-modernization/SKILL.md"
+  }
+}

--- a/catalog/dotnet/msbuild-server.json
+++ b/catalog/dotnet/msbuild-server.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:msbuild-server",
+  "displayName": "Msbuild Server",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/msbuild-server/SKILL.md",
+  "description": "Guide for using MSBuild Server to improve CLI build performance.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/msbuild-server/SKILL.md"
+  }
+}

--- a/catalog/dotnet/mtp-hot-reload.json
+++ b/catalog/dotnet/mtp-hot-reload.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:mtp-hot-reload",
+  "displayName": "Mtp Hot Reload",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md",
+  "description": "Suggests using Microsoft Testing Platform (MTP) hot reload to iterate fixes on failing tests without rebuilding.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/mtp-hot-reload/SKILL.md"
+  }
+}

--- a/catalog/dotnet/nuget-trusted-publishing.json
+++ b/catalog/dotnet/nuget-trusted-publishing.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:nuget-trusted-publishing",
+  "displayName": "Nuget Trusted Publishing",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet/skills/nuget-trusted-publishing/SKILL.md",
+  "description": "Set up NuGet trusted publishing (OIDC) on a GitHub Actions repo - replaces long-lived API keys with short-lived tokens.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet/skills/nuget-trusted-publishing/SKILL.md"
+  }
+}

--- a/catalog/dotnet/optimizing-ef-core-queries.json
+++ b/catalog/dotnet/optimizing-ef-core-queries.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:optimizing-ef-core-queries",
+  "displayName": "Optimizing Ef Core Queries",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-data/skills/optimizing-ef-core-queries/SKILL.md",
+  "description": "Optimize Entity Framework Core queries by fixing N+1 problems, choosing correct tracking modes, using compiled queries, and avoiding common...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-data/skills/optimizing-ef-core-queries/SKILL.md"
+  }
+}

--- a/catalog/dotnet/plan-ui-change.json
+++ b/catalog/dotnet/plan-ui-change.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:plan-ui-change",
+  "displayName": "Plan Ui Change",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/plan-ui-change/SKILL.md",
+  "description": "Plan complex Blazor UI features by decomposing them into focused components.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/plan-ui-change/SKILL.md"
+  }
+}

--- a/catalog/dotnet/platform-detection.json
+++ b/catalog/dotnet/platform-detection.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:platform-detection",
+  "displayName": "Platform Detection",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/platform-detection/SKILL.md",
+  "description": "Reference data for detecting the test platform (VSTest vs Microsoft.Testing.Platform) and test framework (MSTest, xUnit, NUnit, TUnit) from project...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/platform-detection/SKILL.md"
+  }
+}

--- a/catalog/dotnet/property-patterns.json
+++ b/catalog/dotnet/property-patterns.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:property-patterns",
+  "displayName": "Property Patterns",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/property-patterns/SKILL.md",
+  "description": "MSBuild property definition patterns: conditional defaults, composition/concatenation, path normalization, trailing slash handling, TFM detection...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/property-patterns/SKILL.md"
+  }
+}

--- a/catalog/dotnet/resolve-project-references.json
+++ b/catalog/dotnet/resolve-project-references.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:resolve-project-references",
+  "displayName": "Resolve Project References",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/resolve-project-references/SKILL.md",
+  "description": "Guide for interpreting ResolveProjectReferences time in MSBuild performance summaries.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/resolve-project-references/SKILL.md"
+  }
+}

--- a/catalog/dotnet/run-tests.json
+++ b/catalog/dotnet/run-tests.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:run-tests",
+  "displayName": "Run Tests",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/run-tests/SKILL.md",
+  "description": "For `dotnet test`: figures out which test platform (VSTest vs Microsoft.Testing.Platform) a project uses from `Directory.Build.props`, `global.json`...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/run-tests/SKILL.md"
+  }
+}

--- a/catalog/dotnet/support-prerendering.json
+++ b/catalog/dotnet/support-prerendering.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:support-prerendering",
+  "displayName": "Support Prerendering",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/support-prerendering/SKILL.md",
+  "description": "Make interactive Blazor components work correctly with prerendering.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/support-prerendering/SKILL.md"
+  }
+}

--- a/catalog/dotnet/system-text-json-net11.json
+++ b/catalog/dotnet/system-text-json-net11.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:system-text-json-net11",
+  "displayName": "System Text Json Net11",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet11/skills/system-text-json-net11/SKILL.md",
+  "description": "Provides guidance on new System.Text.Json APIs introduced in .NET 11.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet11/skills/system-text-json-net11/SKILL.md"
+  }
+}

--- a/catalog/dotnet/target-authoring.json
+++ b/catalog/dotnet/target-authoring.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:target-authoring",
+  "displayName": "Target Authoring",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-msbuild/skills/target-authoring/SKILL.md",
+  "description": "Canonical patterns for writing custom MSBuild targets.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-msbuild/skills/target-authoring/SKILL.md"
+  }
+}

--- a/catalog/dotnet/technology-selection.json
+++ b/catalog/dotnet/technology-selection.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:technology-selection",
+  "displayName": "Technology Selection",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-ai/skills/technology-selection/SKILL.md",
+  "description": "Guides technology selection and implementation of AI and ML features in .NET 8+ applications using ML.NET, Microsoft.Extensions.AI (MEAI), Microsoft...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-ai/skills/technology-selection/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-authoring.json
+++ b/catalog/dotnet/template-authoring.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-authoring",
+  "displayName": "Template Authoring",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-authoring/SKILL.md",
+  "description": "Guides creation and validation of custom dotnet new templates.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-authoring/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-comparison.json
+++ b/catalog/dotnet/template-comparison.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-comparison",
+  "displayName": "Template Comparison",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-comparison/SKILL.md",
+  "description": "Compares two or more dotnet new templates side by side to help users choose between them based on parameters, feature support, frameworks, and...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-comparison/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-discovery.json
+++ b/catalog/dotnet/template-discovery.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-discovery",
+  "displayName": "Template Discovery",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-discovery/SKILL.md",
+  "description": "Helps find, inspect, and compare .NET project templates.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-discovery/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-instantiation.json
+++ b/catalog/dotnet/template-instantiation.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-instantiation",
+  "displayName": "Template Instantiation",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md",
+  "description": "Creates .NET projects from templates with validated parameters, smart defaults, Central Package Management adaptation, and latest NuGet version...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-instantiation/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-smart-defaults.json
+++ b/catalog/dotnet/template-smart-defaults.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-smart-defaults",
+  "displayName": "Template Smart Defaults",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md",
+  "description": "Applies cross-parameter default rules when creating .NET projects with dotnet new, filling gaps consistently without overriding values the user set...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-smart-defaults/SKILL.md"
+  }
+}

--- a/catalog/dotnet/template-validation.json
+++ b/catalog/dotnet/template-validation.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:template-validation",
+  "displayName": "Template Validation",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-template-engine/skills/template-validation/SKILL.md",
+  "description": "Validates custom dotnet new templates for correctness before publishing.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-template-engine/skills/template-validation/SKILL.md"
+  }
+}

--- a/catalog/dotnet/test-analysis-extensions.json
+++ b/catalog/dotnet/test-analysis-extensions.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:test-analysis-extensions",
+  "displayName": "Test Analysis Extensions",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/test-analysis-extensions/SKILL.md",
+  "description": "Provides file paths to language-specific reference files for the test ANALYSIS skills (assertion-quality, test-anti-patterns, test-gap-analysis...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/test-analysis-extensions/SKILL.md"
+  }
+}

--- a/catalog/dotnet/test-anti-patterns.json
+++ b/catalog/dotnet/test-anti-patterns.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:test-anti-patterns",
+  "displayName": "Test Anti Patterns",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/test-anti-patterns/SKILL.md",
+  "description": "Audits an existing test file or suite in any language for anti-patterns and quality issues - produces a severity-ranked report...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/test-anti-patterns/SKILL.md"
+  }
+}

--- a/catalog/dotnet/test-gap-analysis.json
+++ b/catalog/dotnet/test-gap-analysis.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:test-gap-analysis",
+  "displayName": "Test Gap Analysis",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/test-gap-analysis/SKILL.md",
+  "description": "Performs pseudo-mutation analysis on production code in any language to find gaps in existing test suites.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/test-gap-analysis/SKILL.md"
+  }
+}

--- a/catalog/dotnet/test-smell-detection.json
+++ b/catalog/dotnet/test-smell-detection.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:test-smell-detection",
+  "displayName": "Test Smell Detection",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/test-smell-detection/SKILL.md",
+  "description": "Deep-dive audit using the full testsmells.org 19-smell academic catalog for tests in any language.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/test-smell-detection/SKILL.md"
+  }
+}

--- a/catalog/dotnet/test-tagging.json
+++ b/catalog/dotnet/test-tagging.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:test-tagging",
+  "displayName": "Test Tagging",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/test-tagging/SKILL.md",
+  "description": "Analyzes test suites in any language and tags each test with a standardized set of traits (positive, negative, critical-path, boundary, smoke...",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/test-tagging/SKILL.md"
+  }
+}

--- a/catalog/dotnet/thread-abort-migration.json
+++ b/catalog/dotnet/thread-abort-migration.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:thread-abort-migration",
+  "displayName": "Thread Abort Migration",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-upgrade/skills/thread-abort-migration/SKILL.md",
+  "description": "Guides migration of .NET Framework Thread.Abort usage to cooperative cancellation in modern .NET.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-upgrade/skills/thread-abort-migration/SKILL.md"
+  }
+}

--- a/catalog/dotnet/use-js-interop.json
+++ b/catalog/dotnet/use-js-interop.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:use-js-interop",
+  "displayName": "Use Js Interop",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-blazor/skills/use-js-interop/SKILL.md",
+  "description": "Add, review, or fix JavaScript interop in Blazor components.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-blazor/skills/use-js-interop/SKILL.md"
+  }
+}

--- a/catalog/dotnet/writing-mstest-tests.json
+++ b/catalog/dotnet/writing-mstest-tests.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:dotnet:skills:writing-mstest-tests",
+  "displayName": "Writing Mstest Tests",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/dotnet/skills/blob/main/plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md",
+  "description": "Write new MSTest unit tests and fix existing MSTest code using MSTest 3.x/4.x modern APIs and best practices.",
+  "metadata": {
+    "sourceSet": "dotnet-skills",
+    "repoPath": "plugins/dotnet-test/skills/writing-mstest-tests/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspire-deployment.json
+++ b/catalog/microsoft/aspire-deployment.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspire-deployment",
+  "displayName": "Aspire Deployment",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-deployment/SKILL.md",
+  "description": "Deploy Aspire apps from AppHost models to Docker Compose, Kubernetes, Azure, or AWS.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspire-deployment/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspire-init.json
+++ b/catalog/microsoft/aspire-init.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspire-init",
+  "displayName": "Aspire Init",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-init/SKILL.md",
+  "description": "First-run flow for adding Aspire to a repo.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspire-init/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspire-monitoring.json
+++ b/catalog/microsoft/aspire-monitoring.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspire-monitoring",
+  "displayName": "Aspire Monitoring",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-monitoring/SKILL.md",
+  "description": "Observe Aspire apps: logs, traces, metrics, resource state, telemetry export, browser telemetry, and the standalone dashboard.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspire-monitoring/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspire-orchestration.json
+++ b/catalog/microsoft/aspire-orchestration.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspire-orchestration",
+  "displayName": "Aspire Orchestration",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-orchestration/SKILL.md",
+  "description": "Manage Aspire AppHost lifecycle and recover from file locks, port conflicts, and orphaned processes.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspire-orchestration/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspire.json
+++ b/catalog/microsoft/aspire.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspire",
+  "displayName": "Aspire",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspire/SKILL.md",
+  "description": "Top-level router for Aspire 13.4 distributed apps.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspire/SKILL.md"
+  }
+}

--- a/catalog/microsoft/aspireify.json
+++ b/catalog/microsoft/aspireify.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:microsoft:aspire-skills:aspireify",
+  "displayName": "Aspireify",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md",
+  "description": "Wire an Aspire AppHost after `aspire init` drops a skeleton.",
+  "metadata": {
+    "sourceSet": "aspire-skills",
+    "repoPath": "skills/aspireify/SKILL.md"
+  }
+}


### PR DESCRIPTION
## Summary

Adds 105 `application/ai-skill` entries to the catalog, covering skills from the `dotnet/skills` and `microsoft/aspire-skills` repositories that were not yet listed here.

## Motivation

These skills are published and in use but missing from the catalog. Adding them makes the catalog a complete, authoritative source for these skill sets, so downstream consumers can discover, update, and reconcile entries by matching identifiers.

## Changes

- Adds 105 files under `catalog/<publisher>/<name>.json`, where `<publisher>` is the URN segment following `github.com:` and `<name>` is the final URN segment, consistent with the existing catalog convention.
  - 99 under `catalog/dotnet/`
  - 6 under `catalog/microsoft/`
- All entries use `mediaType: application/ai-skill` and follow the documented schema (`identifier`, `displayName`, `mediaType`, `url`, `description`, `metadata.sourceSet`, `metadata.repoPath`).
- No existing files modified; no path collisions.

## Validation

- All files are valid JSON.
- Each file's folder matches its identifier's publisher, and each filename matches its identifier's final segment.
- No duplicate identifiers across the catalog.
- Source URLs resolve to published `SKILL.md` definitions.
