### PR TITLE
Add Sparkient Decision Intelligence MCP server

### DIFF
--- a/catalog/sparkient/sparkient-decision-api.json
+++ b/catalog/sparkient/sparkient-decision-api.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:Sparkient:sparkient-mcp-server:decision-api",
+  "displayName": "Sparkient Decision Intelligence",
+  "mediaType": "application/mcp-server-card+json",
+  "url": "https://mcp.sparkient.ai/mcp",
+  "description": "Sub-100ms decision intelligence MCP server. Compiles LLM intelligence into fast ML models for content moderation, routing, classification, and gating at 33-42ms p95 latency. 13 tools for decisions, training, and edge export.",
+  "metadata": {
+    "sourceSet": "sparkient-mcp-server",
+    "repoPath": "README.md"
+  }
+}


### PR DESCRIPTION
## Summary
Adds the Sparkient Decision Intelligence MCP server to the Agent Finder catalog.

## What is Sparkient?
Sparkient is a sub-100ms decision intelligence API that compiles LLM intelligence into fast ML models for content moderation, routing, classification, and gating. It achieves 33-42ms p95 latency — fast enough to sit in hot paths where direct LLM calls are too slow.

## Details
- **13 MCP tools**: make_decision, batch_decisions, create_decision_type, train_model, export_edge_bundle, and more
- **MCP endpoint**: https://mcp.sparkient.ai/mcp (Streamable HTTP)
- **Documentation**: https://docs.sparkient.ai/docs/
- **ARD catalog**: https://sparkient.ai/.well-known/ai-catalog.json
- **Verified on Smithery.ai**: https://smithery.ai/servers/sparkient/sparkient