### PR TITLE
Add BountyVerdict agent decision tools

### DIFF
--- a/catalog/cristianmoroaica/bountyverdict.json
+++ b/catalog/cristianmoroaica/bountyverdict.json
@@ -3,7 +3,7 @@
   "displayName": "BountyVerdict Agent Decision Tools",
   "mediaType": "application/mcp-server+json",
   "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.cristianmoroaica%2Fbountyverdict/versions/latest",
-  "description": "Choose GitHub bounties, diagnose Actions failures, audit agent instructions, and detect MCP drift.",
+  "description": "Read-only GitHub bounty, agent harness, Actions failure, flake, and MCP tool-drift decisions.",
   "metadata": {
     "sourceSet": "bountyverdict",
     "repoPath": "server.json",

--- a/catalog/cristianmoroaica/bountyverdict.json
+++ b/catalog/cristianmoroaica/bountyverdict.json
@@ -1,0 +1,13 @@
+{
+  "identifier": "urn:ai:registry.modelcontextprotocol.io:io.github.cristianmoroaica:bountyverdict",
+  "displayName": "BountyVerdict Agent Decision Tools",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.cristianmoroaica%2Fbountyverdict/versions/latest",
+  "description": "Choose GitHub bounties, diagnose Actions failures, audit agent instructions, and detect MCP drift.",
+  "metadata": {
+    "sourceSet": "bountyverdict",
+    "repoPath": "server.json",
+    "serverName": "io.github.cristianmoroaica/bountyverdict",
+    "version": "latest"
+  }
+}


### PR DESCRIPTION
## Summary

Adds BountyVerdict's six read-only agent decision tools to the Agent Finder catalog through the server's stable official MCP Registry `latest` URL.

The tools help agents:

- check one public GitHub bounty or rank 2–10 bounty opportunities;
- audit repository instructions before assigning a coding agent;
- diagnose a failed public GitHub Actions run or decide whether one retry is appropriate; and
- detect breaking MCP `tools/list` drift.

Calls are paid through x402 USDC. The linked Registry record publishes each tool's exact price and result contract.

## Verification

- The Registry record reports `io.github.cristianmoroaica/bountyverdict@1.1.1` as active and latest.
- Its Streamable HTTP remote is `https://bountyverdict-agent-production.mimirslab.workers.dev/mcp`.
- The catalog description exactly matches the live Registry description.
- `python -m json.tool` passes for the added file.
- All 1,130 catalog JSON files parse with `jq`, identifiers remain unique, and `git diff --check` passes.

This pull request requests catalog review; it does not imply prior GitHub approval or curation.
