### PR TITLE
Add canonical BountyVerdict agent decision tools

### DIFF
--- a/catalog/Mimirs402/bountyverdict.json
+++ b/catalog/Mimirs402/bountyverdict.json
@@ -1,0 +1,13 @@
+{
+  "identifier": "urn:ai:registry.modelcontextprotocol.io:io.github.Mimirs402:bountyverdict",
+  "displayName": "BountyVerdict Agent Decision Tools",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.Mimirs402%2Fbountyverdict/versions/latest",
+  "description": "Read-only GitHub bounty, agent harness, Actions failure, flake, and MCP tool-drift decisions.",
+  "metadata": {
+    "sourceSet": "bountyverdict",
+    "repoPath": "server.json",
+    "serverName": "io.github.Mimirs402/bountyverdict",
+    "version": "latest"
+  }
+}

--- a/catalog/Mimirs402/bountyverdict.json
+++ b/catalog/Mimirs402/bountyverdict.json
@@ -1,9 +1,9 @@
 {
-  "identifier": "urn:ai:registry.modelcontextprotocol.io:io.github.Mimirs402:bountyverdict",
+  "identifier": "urn:ai:github.com:Mimirs402:bountyverdict:bountyverdict",
   "displayName": "BountyVerdict Agent Decision Tools",
   "mediaType": "application/mcp-server+json",
-  "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.Mimirs402%2Fbountyverdict/versions/latest",
-  "description": "Read-only GitHub bounty, agent harness, Actions failure, flake, and MCP tool-drift decisions.",
+  "url": "https://github.com/Mimirs402/bountyverdict/blob/main/server.json",
+  "description": "Check whether a GitHub bounty is worth pursuing, diagnose why an Actions run failed, decide whether to retry a flake, audit AGENTS.md, or detect breaking MCP tool drift.",
   "metadata": {
     "sourceSet": "bountyverdict",
     "repoPath": "server.json",


### PR DESCRIPTION
## Summary

Adds the canonical Mimir's Lab BountyVerdict MCP server to the Agent Finder catalog using the current direct-contribution contract.

The six existing read-only tools help agents decide whether a public GitHub bounty is worth pursuing, audit repository instructions, diagnose failed GitHub Actions runs, decide whether one retry is appropriate, and detect breaking MCP tool drift. Calls use the existing x402 USDC contracts.

This supersedes #10, whose immutable source branch references the retired personal publisher. The product behavior is unchanged; the catalog identity and source now belong to `Mimirs402`.

## Current-schema update

- Rebased onto current catalog main after #12.
- Uses the documented `urn:ai:github.com:<publisher>:<repo>:<augment>` identifier.
- Links the public source definition at `Mimirs402/bountyverdict/blob/main/server.json`.
- Keeps the MCP media type and repository-owned `sourceSet` / `repoPath` metadata.
- Leads with the questions an agent would actually ask rather than internal product labels.

## Verification

- The linked `server.json` exists on the canonical business repository and declares the production Streamable HTTP MCP remote.
- Every catalog JSON file parses.
- Catalog identifiers remain unique.
- `git diff --check` passes.

This requests catalog review and does not represent an impression, install, purchase, or revenue event.
