### PR TITLE
Prefer publisher display names for MCP servers

### DIFF
--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -23378,7 +23378,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:04:28Z",
+      "updatedAt": "2026-08-18T18:44:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -23393,7 +23393,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-06T13:04:29Z",
+      "updatedAt": "2026-08-18T18:44:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -23403,10 +23403,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.epinu:epinu",
-      "displayName": "ai.epinu/epinu",
+      "displayName": "Epinu",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.epinu%2Fepinu/versions/1.0.2",
-      "description": "Agent-first marketplace for industrial assets & livestock medianería; humans approve every write.",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.epinu%2Fepinu/versions/1.0.4",
+      "description": "Agent-first marketplace for real-world assets — agro and energy first; humans approve every write.",
       "tags": [
         "agentic-commerce",
         "agriculture",
@@ -23417,8 +23417,8 @@
         "real-world-assets",
         "medianeria"
       ],
-      "version": "1.0.2",
-      "updatedAt": "2026-08-06T13:04:30Z",
+      "version": "1.0.4",
+      "updatedAt": "2026-08-18T18:44:12Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -23433,7 +23433,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-06T13:04:31Z",
+      "updatedAt": "2026-08-18T18:44:14Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -23444,7 +23444,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.keenable:web-search",
-      "displayName": "ai.keenable/web-search",
+      "displayName": "Keenable Web Search",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/ai.keenable%2Fweb-search/versions/0.1.2",
       "description": "Live web search and clean-markdown page fetch over the Keenable web index.",
@@ -23457,7 +23457,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-06T13:04:33Z",
+      "updatedAt": "2026-08-18T18:44:15Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -23470,7 +23470,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.nauro:nauro",
       "displayName": "Nauro",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.11.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.14.1",
       "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
       "tags": [
         "agentic-ai",
@@ -23483,8 +23483,8 @@
         "model-context-protocol",
         "claude-code"
       ],
-      "version": "1.11.0",
-      "updatedAt": "2026-08-06T13:04:34Z",
+      "version": "1.14.1",
+      "updatedAt": "2026-08-18T18:44:16Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -23496,10 +23496,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.plori:plori",
-      "displayName": "ai.plori/plori",
+      "displayName": "Plori",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.4.1",
-      "description": "Create and drive plori cloud agents and workflows over MCP; each agent has its own cloud computer.",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.9.1",
+      "description": "Create and drive plori cloud agents and workflows over MCP; each agent has its own environment.",
       "tags": [
         "ai-agents",
         "claude",
@@ -23507,8 +23507,8 @@
         "mcp-server",
         "model-context-protocol"
       ],
-      "version": "0.4.1",
-      "updatedAt": "2026-08-06T13:04:35Z",
+      "version": "0.9.1",
+      "updatedAt": "2026-08-18T18:44:17Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -23536,13 +23536,13 @@
         "mcp-server"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-06T13:04:36Z",
+      "updatedAt": "2026-08-18T18:44:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
         "repository": "https://github.com/vaaya-ai/vaaya-mcp",
         "repositorySource": "github",
-        "stargazerCount": 35,
+        "stargazerCount": 38,
         "websiteUrl": "https://vaaya.ai"
       }
     },
@@ -23553,7 +23553,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-06T13:04:38Z",
+      "updatedAt": "2026-08-18T18:44:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -23579,12 +23579,12 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-06T13:04:39Z",
+      "updatedAt": "2026-08-18T18:44:21Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
         "repositorySource": "github",
-        "stargazerCount": 4,
+        "stargazerCount": 9,
         "websiteUrl": "https://mcp.desktopcommander.app"
       }
     },
@@ -23603,12 +23603,12 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:04:40Z",
+      "updatedAt": "2026-08-18T18:44:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 199,
+        "stargazerCount": 202,
         "websiteUrl": "https://glif.app/mcp"
       }
     },
@@ -23619,7 +23619,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:04:41Z",
+      "updatedAt": "2026-08-18T18:44:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -23629,10 +23629,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:app.sentinelx:sentinelx",
-      "displayName": "SentinelX",
+      "displayName": "SentinelX MCP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/app.sentinelx%2Fsentinelx/versions/0.2.1",
-      "description": "Operate your Linux servers from your LLM. Every action runs through an auditable allowlist.",
+      "url": "https://api.mcp.github.com/v0.1/servers/app.sentinelx%2Fsentinelx/versions/0.6.0",
+      "description": "Operate Linux, macOS and Windows from your LLM. Every action runs through an auditable allowlist.",
       "tags": [
         "agent",
         "chatgpt",
@@ -23645,21 +23645,21 @@
         "sentinelx",
         "websocket"
       ],
-      "version": "0.2.1",
-      "updatedAt": "2026-08-06T13:04:43Z",
+      "version": "0.6.0",
+      "updatedAt": "2026-08-18T18:44:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
         "repository": "https://github.com/pensados/sentinelx-cloud-core",
         "repositorySource": "github",
-        "stargazerCount": 2
+        "stargazerCount": 5
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:cloud.dchub:mcp-server",
       "displayName": "DC Hub — Data Center & Power Intelligence",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.11.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.12.0",
       "description": "Data-center, grid, fiber & gas infrastructure intelligence for AI agents — query and cite.",
       "tags": [
         "ai-tools",
@@ -23673,8 +23673,8 @@
         "market-intelligence",
         "mcp"
       ],
-      "version": "2.11.1",
-      "updatedAt": "2026-08-06T13:04:44Z",
+      "version": "2.12.0",
+      "updatedAt": "2026-08-18T18:44:25Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -23688,8 +23688,8 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:co.tempguru:event-staffing",
       "displayName": "TempGuru Event Staffing",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/co.tempguru%2Fevent-staffing/versions/1.6.0",
-      "description": "Plan, price, and request quotes for W-2 event staff across 345 US/CA markets; rates and compliance.",
+      "url": "https://api.mcp.github.com/v0.1/servers/co.tempguru%2Fevent-staffing/versions/1.7.2",
+      "description": "Plan W-2 event staffing from 345 catalog entries; a coordinator confirms each order.",
       "tags": [
         "agent-skills",
         "ai-agents",
@@ -23702,15 +23702,15 @@
         "brand-ambassadors",
         "w2-staffing"
       ],
-      "version": "1.6.0",
-      "updatedAt": "2026-08-06T13:04:46Z",
+      "version": "1.7.2",
+      "updatedAt": "2026-08-18T18:44:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
         "repository": "https://github.com/tempguru-co/tempguru-mcp",
         "repositorySource": "github",
         "stargazerCount": 2,
-        "websiteUrl": "https://tempguru.co/ai"
+        "websiteUrl": "https://tempguru.co/ai-agents"
       }
     },
     {
@@ -23720,7 +23720,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-06T13:04:50Z",
+      "updatedAt": "2026-08-18T18:44:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -23735,7 +23735,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:04:51Z",
+      "updatedAt": "2026-08-18T18:44:32Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23751,7 +23751,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:04:52Z",
+      "updatedAt": "2026-08-18T18:44:33Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23767,7 +23767,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:04:53Z",
+      "updatedAt": "2026-08-18T18:44:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23783,7 +23783,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:04:54Z",
+      "updatedAt": "2026-08-18T18:44:35Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23799,7 +23799,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:04:55Z",
+      "updatedAt": "2026-08-18T18:44:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23815,7 +23815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:04:56Z",
+      "updatedAt": "2026-08-18T18:44:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23831,7 +23831,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:04:57Z",
+      "updatedAt": "2026-08-18T18:44:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23847,7 +23847,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-06T13:04:59Z",
+      "updatedAt": "2026-08-18T18:44:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23861,13 +23861,39 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-06T13:05:00Z",
+      "updatedAt": "2026-08-18T18:44:40Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
         "repository": "https://github.com/durwardjohnson/breckenwander-travel-connector",
         "repositorySource": "github",
         "websiteUrl": "https://breckenwander.com"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.chainstack:chainstack",
+      "displayName": "Chainstack",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.chainstack%2Fchainstack/versions/1.10.10",
+      "description": "Deploy and manage blockchain nodes across 70+ protocols, search docs, request testnet funds.",
+      "tags": [
+        "blockchain",
+        "mcp",
+        "ai-agents",
+        "blockchain-nodes",
+        "mcp-server",
+        "model-context-protocol",
+        "rpc",
+        "web3"
+      ],
+      "version": "1.10.10",
+      "updatedAt": "2026-08-18T18:44:41Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
+        "repository": "https://github.com/chainstacklabs/mcp-server",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://docs.chainstack.com/docs/chainstack-mcp-server"
       }
     },
     {
@@ -23889,7 +23915,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-06T13:05:01Z",
+      "updatedAt": "2026-08-18T18:44:42Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23906,7 +23932,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.2",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.2",
-      "updatedAt": "2026-08-06T13:05:02Z",
+      "updatedAt": "2026-08-18T18:44:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23915,7 +23941,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.getappniche:mcp",
-      "displayName": "com.getappniche/mcp",
+      "displayName": "Getappniche",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/com.getappniche%2Fmcp/versions/1.2.0",
       "description": "Live App Store & Google Play data for AI agents: app discovery, ASO keywords, reviews.",
@@ -23931,13 +23957,28 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-06T13:05:05Z",
+      "updatedAt": "2026-08-18T18:44:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
         "repository": "https://github.com/getappniche/mcp",
         "repositorySource": "github",
         "websiteUrl": "https://getappniche.com/mcp"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.getfirmament:firmament",
+      "displayName": "Firmament",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
+      "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
+      "version": "0.1.1",
+      "updatedAt": "2026-08-18T18:44:47Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
+        "repository": "https://github.com/spkenny455/firmament-mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://getfirmament.com"
       }
     },
     {
@@ -23956,12 +23997,12 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:05:07Z",
+      "updatedAt": "2026-08-18T18:44:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://www.getwpagent.com/docs"
       }
     },
@@ -23972,7 +24013,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-06T13:05:09Z",
+      "updatedAt": "2026-08-18T18:44:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -23982,7 +24023,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.imnoo:drawing-converter",
-      "displayName": "com.imnoo/drawing-converter",
+      "displayName": "Imnoo Drawing Converter",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/com.imnoo%2Fdrawing-converter/versions/0.1.0",
       "description": "Metric ⇄ imperial for technical drawings: dimensions, tolerances, ISO fits, threads, roughness.",
@@ -23999,7 +24040,7 @@
         "technical-drawing"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-06T13:05:11Z",
+      "updatedAt": "2026-08-18T18:44:54Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -24010,10 +24051,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.longbridge:mcp",
-      "displayName": "com.longbridge/mcp",
+      "displayName": "Longbridge",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.longbridge%2Fmcp/versions/0.8.6",
-      "description": "US/HK markets — 151 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.longbridge%2Fmcp/versions/0.8.7",
+      "description": "US/HK markets — 152 tools: quotes, options, orders, fundamentals, screener, IPO, alerts & DCA",
       "tags": [
         "finance",
         "longbridge",
@@ -24022,14 +24063,14 @@
         "model-context-protocol",
         "trading"
       ],
-      "version": "0.8.6",
-      "updatedAt": "2026-08-06T13:05:12Z",
+      "version": "0.8.7",
+      "updatedAt": "2026-08-18T18:44:55Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
         "repository": "https://github.com/longbridge/longbridge-mcp",
         "repositorySource": "github",
-        "stargazerCount": 11,
+        "stargazerCount": 12,
         "websiteUrl": "https://longbridge.com"
       }
     },
@@ -24043,7 +24084,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-06T13:05:13Z",
+      "updatedAt": "2026-08-18T18:44:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -24070,7 +24111,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:05:15Z",
+      "updatedAt": "2026-08-18T18:44:57Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -24084,7 +24125,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.mailrith:mailrith",
       "displayName": "Mailrith Email Marketing",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.0.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.1.0",
       "description": "Manage Subscribers, Broadcasts, Sequences, Automations, and reporting in Mailrith.",
       "tags": [
         "ai-agents",
@@ -24095,20 +24136,21 @@
         "typescript",
         "gemini-cli-extension"
       ],
-      "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:05:16Z",
+      "version": "1.1.0",
+      "updatedAt": "2026-08-18T18:44:58Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/anrawool/mailrith-agent-platform",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
+        "stargazerCount": 1,
         "websiteUrl": "https://mailrith.com/developers/mcp"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.memxus:memxus",
-      "displayName": "com.memxus/memxus",
+      "displayName": "Memxus",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/com.memxus%2Fmemxus/versions/1.3.2",
       "description": "Persistent memory layer that saves and recalls your project context and preferences.",
@@ -24121,7 +24163,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-06T13:05:17Z",
+      "updatedAt": "2026-08-18T18:44:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -24140,20 +24182,20 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:05:24Z",
+      "updatedAt": "2026-08-18T18:45:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 24
+        "stargazerCount": 26
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.negativeev:bet-checker",
-      "displayName": "com.negativeev/bet-checker",
+      "displayName": "Negativeev Bet Checker",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.2",
-      "description": "Grade any bet against thousands of play-by-play game simulations: win probability, odds, edge.",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.3",
+      "description": "Grade any MLB, WNBA, PGA or ATP bet against thousands of play-by-play game simulations.",
       "tags": [
         "claude",
         "mcp",
@@ -24161,8 +24203,8 @@
         "simulation",
         "sports-betting"
       ],
-      "version": "1.4.2",
-      "updatedAt": "2026-08-06T13:05:26Z",
+      "version": "1.4.3",
+      "updatedAt": "2026-08-18T18:45:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
         "repository": "https://github.com/negative-ev/negativeev-mcp",
@@ -24177,7 +24219,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-06T13:05:28Z",
+      "updatedAt": "2026-08-18T18:45:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -24192,7 +24234,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-06T13:05:31Z",
+      "updatedAt": "2026-08-18T18:45:12Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -24219,7 +24261,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-06T13:05:33Z",
+      "updatedAt": "2026-08-18T18:45:15Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -24245,7 +24287,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-06T13:05:34Z",
+      "updatedAt": "2026-08-18T18:45:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -24261,12 +24303,40 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.47.27",
-      "updatedAt": "2026-08-06T13:05:35Z",
+      "updatedAt": "2026-08-18T18:45:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
         "repositorySource": "github",
         "websiteUrl": "https://helpdesk.sherweb.com/en-us/knowledge-base/articles/KA-05021"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.smartbear:swagger-mcp",
+      "displayName": "Swagger MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.smartbear%2Fswagger-mcp/versions/0.33.0",
+      "description": "MCP server for AI access to Swagger by SmartBear.",
+      "tags": [
+        "bugsnag",
+        "mcp",
+        "mcp-server",
+        "reflect",
+        "smartbear",
+        "vscode",
+        "open-source",
+        "pactflow",
+        "portal",
+        "swagger"
+      ],
+      "version": "0.33.0",
+      "updatedAt": "2026-08-18T18:45:21Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
+        "repository": "https://github.com/SmartBear/smartbear-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 43
       }
     },
     {
@@ -24279,7 +24349,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-06T13:05:41Z",
+      "updatedAt": "2026-08-18T18:45:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -24296,7 +24366,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.1.2",
-      "updatedAt": "2026-08-06T13:05:47Z",
+      "updatedAt": "2026-08-18T18:45:29Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -24324,11 +24394,12 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-06T13:05:52Z",
+      "updatedAt": "2026-08-18T18:45:33Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
         "repositorySource": "github",
+        "stargazerCount": 1,
         "websiteUrl": "https://www.wpwriter.com/docs/mcp"
       }
     },
@@ -24349,7 +24420,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-06T13:05:53Z",
+      "updatedAt": "2026-08-18T18:45:34Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -24377,13 +24448,13 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-06T13:05:55Z",
+      "updatedAt": "2026-08-18T18:45:36Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
         "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
         "repositorySource": "github",
-        "stargazerCount": 176,
+        "stargazerCount": 183,
         "websiteUrl": "https://docs.xquik.com/mcp/overview"
       }
     },
@@ -24404,13 +24475,39 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-06T13:05:56Z",
+      "updatedAt": "2026-08-18T18:45:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
         "repositorySource": "github",
-        "stargazerCount": 2,
+        "stargazerCount": 3,
         "websiteUrl": "https://lovable.dev"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:dev.mailkite:mailkite",
+      "displayName": "Mailkite",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/dev.mailkite%2Fmailkite/versions/0.13.0",
+      "description": "Send email, manage domains, DNS, webhooks, templates, and inbound routing on MailKite",
+      "tags": [
+        "mcp",
+        "mcp-server",
+        "ai-agents",
+        "email",
+        "email-api",
+        "llm-tools",
+        "mailkite",
+        "model-context-protocol"
+      ],
+      "version": "0.13.0",
+      "updatedAt": "2026-08-18T18:45:38Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
+        "repository": "https://github.com/mailkite/mailkite-mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://mailkite.dev/docs/ai-agents"
       }
     },
     {
@@ -24420,12 +24517,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-06T13:05:58Z",
+      "updatedAt": "2026-08-18T18:45:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://vibeseo.dev/mcp"
       }
     },
@@ -24436,7 +24533,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-06T13:05:59Z",
+      "updatedAt": "2026-08-18T18:45:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -24447,7 +24544,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.alterlab:mcp-server",
-      "displayName": "io.alterlab/mcp-server",
+      "displayName": "Alterlab",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.alterlab%2Fmcp-server/versions/1.8.0",
       "description": "Web scraping MCP server — scrape, extract structured data, screenshot any site with anti-bot bypass.",
@@ -24464,7 +24561,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-06T13:06:03Z",
+      "updatedAt": "2026-08-18T18:45:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24492,7 +24589,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-06T13:06:04Z",
+      "updatedAt": "2026-08-18T18:45:45Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24521,8 +24618,9 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:06:05Z",
+      "updatedAt": "2026-08-18T18:45:46Z",
       "metadata": {
+        "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
         "repository": "https://github.com/webmilmind1/deskcrew-mcp",
         "repositorySource": "github",
@@ -24549,7 +24647,7 @@
         "ai-native"
       ],
       "version": "1.16.3",
-      "updatedAt": "2026-08-06T13:06:07Z",
+      "updatedAt": "2026-08-18T18:45:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24560,7 +24658,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.AlvisoOculus:optionsahoy-mcp",
-      "displayName": "io.github.AlvisoOculus/optionsahoy-mcp",
+      "displayName": "AlvisoOculus Optionsahoy",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AlvisoOculus%2Foptionsahoy-mcp/versions/1.10.1",
       "description": "Equity comp tax/trade optimizer: ISO/AMT exercise, NSO, RSU, QSBS, concentration, hedging. 50-state.",
@@ -24577,7 +24675,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-06T13:06:08Z",
+      "updatedAt": "2026-08-18T18:45:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24594,7 +24692,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-06T13:06:11Z",
+      "updatedAt": "2026-08-18T18:45:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24609,13 +24707,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.4.1",
-      "updatedAt": "2026-08-06T13:06:14Z",
+      "updatedAt": "2026-08-18T18:45:53Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
         "repository": "https://github.com/ClickHouse/mcp-clickhouse",
         "repositorySource": "github",
-        "stargazerCount": 843,
+        "stargazerCount": 852,
         "websiteUrl": "https://clickhouse.com"
       }
     },
@@ -24626,7 +24724,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-06T13:06:15Z",
+      "updatedAt": "2026-08-18T18:45:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
@@ -24637,7 +24735,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Decodo:mcp-server",
-      "displayName": "io.github.Decodo/mcp-server",
+      "displayName": "Decodo",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Decodo%2Fmcp-server/versions/1.2.3",
       "description": "Enable your AI agents to scrape and parse web content dynamically, including geo-restricted sites",
@@ -24654,7 +24752,7 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-06T13:06:17Z",
+      "updatedAt": "2026-08-18T18:45:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
@@ -24680,7 +24778,7 @@
         "scaffolding"
       ],
       "version": "15.5.1",
-      "updatedAt": "2026-08-06T13:06:20Z",
+      "updatedAt": "2026-08-18T18:45:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24708,7 +24806,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-06T13:06:21Z",
+      "updatedAt": "2026-08-18T18:46:00Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24721,17 +24819,45 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Krv-Labs:topos",
       "displayName": "Topos",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.4.4",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
-      "version": "0.4.4",
-      "updatedAt": "2026-08-06T11:52:38Z",
+      "version": "0.5.1",
+      "updatedAt": "2026-08-18T18:46:01Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
         "repository": "https://github.com/Krv-Labs/topos",
         "repositorySource": "github",
-        "stargazerCount": 20,
+        "stargazerCount": 23,
         "websiteUrl": "https://github.com/Krv-Labs/topos"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.MachuraHarry:pipe",
+      "displayName": "Pipe (SPR) MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.MachuraHarry%2Fpipe/versions/1.0.0",
+      "description": "AI-native runtime with built-in MCP server. 232 builtins, AI pipelines, RAG, single ~8 MB binary.",
+      "tags": [
+        "ai",
+        "golang",
+        "llm",
+        "pipeline",
+        "spr",
+        "ai-agents",
+        "devtools",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-08-18T18:46:02Z",
+      "metadata": {
+        "primaryLanguage": "Go",
+        "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
+        "repository": "https://github.com/MachuraHarry/pipe",
+        "repositorySource": "github",
+        "stargazerCount": 2
       }
     },
     {
@@ -24753,7 +24879,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-06T13:06:53Z",
+      "updatedAt": "2026-08-18T18:46:04Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24764,7 +24890,7 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.OctoPerf:octoperf",
-      "displayName": "io.github.OctoPerf/octoperf",
+      "displayName": "OctoPerf",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.OctoPerf%2Foctoperf/versions/1.0.0",
       "description": "Drive OctoPerf load testing from any AI agent: import, edit, validate, run scenarios, read metrics.",
@@ -24772,7 +24898,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:06:54Z",
+      "updatedAt": "2026-08-18T18:46:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24782,12 +24908,12 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Omnidim:omnidim-mcp-server",
-      "displayName": "io.github.Omnidim/omnidim-mcp-server",
+      "displayName": "Omnidim",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
       "version": "0.8.0",
-      "updatedAt": "2026-08-06T13:06:55Z",
+      "updatedAt": "2026-08-18T18:46:06Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
@@ -24801,35 +24927,39 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.PascaleBeier:hitkeep",
       "displayName": "HitKeep",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.PascaleBeier%2Fhitkeep/versions/2.13.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.PascaleBeier%2Fhitkeep/versions/2.13.9",
       "description": "Stateless 2026-07-28 read-only MCP server for aggregate HitKeep analytics and official docs.",
       "tags": [
         "analytics",
-        "angular",
         "go",
-        "ai",
-        "mcp",
-        "agent-skills"
+        "ai-analytics",
+        "ai-visibility",
+        "analytics-dashboard",
+        "conversion-analytics",
+        "cookieless",
+        "duckdb",
+        "ecommerce-analytics",
+        "google-analytics-alternative"
       ],
-      "version": "2.13.3",
-      "updatedAt": "2026-08-06T13:06:57Z",
+      "version": "2.13.9",
+      "updatedAt": "2026-08-18T18:46:08Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
         "repository": "https://github.com/pascalebeier/hitkeep",
         "repositorySource": "github",
-        "stargazerCount": 79,
+        "stargazerCount": 82,
         "websiteUrl": "https://hitkeep.com/use-cases/read-only-mcp-server-web-analytics/"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.QWarranto:leafengines",
-      "displayName": "io.github.QWarranto/leafengines",
+      "displayName": "QWarranto Leafengines",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-06T13:06:59Z",
+      "updatedAt": "2026-08-18T18:46:09Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24845,12 +24975,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.SEKeener%2Fairtreks-mcp/versions/1.0.2",
       "description": "Multi-city flight routing intelligence — plan RTW trips, validate alliances, get carrier picks.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-06T13:07:01Z",
+      "updatedAt": "2026-08-18T18:46:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SEKeener/airtreks-mcp#readme",
         "repository": "https://github.com/SEKeener/airtreks-mcp",
         "repositorySource": "github",
+        "stargazerCount": 1,
         "websiteUrl": "https://airtreks.com"
       }
     },
@@ -24858,7 +24989,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Sendmux:sendmux-mcp",
       "displayName": "Email Inbox API + Sending by Sendmux",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Sendmux%2Fsendmux-mcp/versions/1.5.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Sendmux%2Fsendmux-mcp/versions/1.6.0",
       "description": "AI email inbox and sending tools with attachments, search, live events, and webhooks.",
       "tags": [
         "cli",
@@ -24872,8 +25003,8 @@
         "mcp-server",
         "mcp-tools"
       ],
-      "version": "1.5.0",
-      "updatedAt": "2026-08-06T11:53:28Z",
+      "version": "1.6.0",
+      "updatedAt": "2026-08-18T18:46:14Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
@@ -24888,22 +25019,21 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Vortx-AI:emem",
       "displayName": "emem, the verifiable memory protocol for the physical world",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.0.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.1.0",
       "description": "Shared, verifiable memory for AI agents and robots: signed tokens that resolve and verify offline.",
       "tags": [
         "ai-agents",
-        "memory",
-        "ed25519",
         "long-term-memory",
         "world-models",
-        "mcp",
         "model-context-protocol",
-        "agent-memory",
         "earth-observation",
-        "mcp-server"
+        "mcp-server",
+        "long-running-agents",
+        "rust",
+        "a2a-protocol"
       ],
-      "version": "2.0.0",
-      "updatedAt": "2026-08-06T13:07:37Z",
+      "version": "2.1.0",
+      "updatedAt": "2026-08-18T18:46:20Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -24927,7 +25057,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-06T13:07:40Z",
+      "updatedAt": "2026-08-18T18:46:22Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -24955,12 +25085,12 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-06T13:07:41Z",
+      "updatedAt": "2026-08-18T18:46:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
         "repositorySource": "github",
-        "stargazerCount": 10,
+        "stargazerCount": 12,
         "websiteUrl": "https://adkit.so"
       }
     },
@@ -24968,7 +25098,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.agentic-hil:agentic-hil",
       "displayName": "Agentic HIL",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.8.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.16.0",
       "description": "Policy-gated MCP tools for embedded hardware-in-the-loop testing on real devices.",
       "tags": [
         "embedded",
@@ -24982,14 +25112,14 @@
         "stlink",
         "ai-agents"
       ],
-      "version": "0.8.0",
-      "updatedAt": "2026-08-06T13:07:42Z",
+      "version": "0.16.0",
+      "updatedAt": "2026-08-18T18:46:25Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
         "repository": "https://github.com/agentic-hil/agentic-hil",
         "repositorySource": "github",
-        "stargazerCount": 9,
+        "stargazerCount": 12,
         "websiteUrl": "https://github.com/agentic-hil/agentic-hil"
       }
     },
@@ -25012,19 +25142,19 @@
         "ai-tools"
       ],
       "version": "0.4.0",
-      "updatedAt": "2026-08-06T13:07:44Z",
+      "updatedAt": "2026-08-18T18:46:26Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
         "repository": "https://github.com/aoreshkov/kotlin-lib-mcp",
         "repositorySource": "github",
-        "stargazerCount": 7,
+        "stargazerCount": 8,
         "websiteUrl": "https://github.com/aoreshkov/kotlin-lib-mcp"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.basicmachines-co:basic-memory",
-      "displayName": "io.github.basicmachines-co/basic-memory",
+      "displayName": "Basicmachines Co Basic Memory",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.basicmachines-co%2Fbasic-memory/versions/0.22.1",
       "description": "Local-first knowledge management with bi-directional LLM sync via Markdown files.",
@@ -25041,13 +25171,13 @@
         "knowlege-graph"
       ],
       "version": "0.22.1",
-      "updatedAt": "2026-08-06T13:07:46Z",
+      "updatedAt": "2026-08-18T18:46:28Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
         "repository": "https://github.com/basicmachines-co/basic-memory.git",
         "repositorySource": "github",
-        "stargazerCount": 3593
+        "stargazerCount": 3678
       }
     },
     {
@@ -25069,7 +25199,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-06T13:07:52Z",
+      "updatedAt": "2026-08-18T18:46:33Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -25098,13 +25228,13 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-06T13:07:53Z",
+      "updatedAt": "2026-08-18T18:46:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
         "repository": "https://github.com/cometchat/docs-mcp",
         "repositorySource": "github",
-        "stargazerCount": 44,
+        "stargazerCount": 54,
         "websiteUrl": "https://www.cometchat.com/docs/mcp-server"
       }
     },
@@ -25115,7 +25245,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-06T13:07:56Z",
+      "updatedAt": "2026-08-18T18:46:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25143,7 +25273,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.3",
-      "updatedAt": "2026-08-06T13:07:57Z",
+      "updatedAt": "2026-08-18T18:46:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -25156,23 +25286,23 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.flinker-app:ifc-mcp",
       "displayName": "IFC MCP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.16",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
-      "version": "0.1.16",
-      "updatedAt": "2026-08-06T13:08:02Z",
+      "version": "0.1.17",
+      "updatedAt": "2026-08-18T18:46:42Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
         "repository": "https://github.com/flinker-app/ifc-mcp",
         "repositorySource": "github",
-        "stargazerCount": 7
+        "stargazerCount": 11
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.hostinger:hostinger-api-mcp",
-      "displayName": "io.github.hostinger/hostinger-api-mcp",
+      "displayName": "Hostinger API",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.30.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.42.0",
       "description": "MCP server for Hostinger API",
       "tags": [
         "ai",
@@ -25183,21 +25313,21 @@
         "mcp",
         "gemini-cli-extension"
       ],
-      "version": "1.30.0",
-      "updatedAt": "2026-08-06T13:08:10Z",
+      "version": "1.42.0",
+      "updatedAt": "2026-08-18T18:46:50Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
         "repository": "https://github.com/hostinger/api-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 137
+        "stargazerCount": 142
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.ihor-sokoliuk:mcp-searxng",
       "displayName": "SearXNG Search",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/1.14.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/1.15.0",
       "description": "MCP server for SearXNG — privacy-respecting web search with pagination, URL reading",
       "tags": [
         "ai",
@@ -25211,21 +25341,21 @@
         "cursor",
         "privacy"
       ],
-      "version": "1.14.0",
-      "updatedAt": "2026-08-06T13:08:12Z",
+      "version": "1.15.0",
+      "updatedAt": "2026-08-18T18:46:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
         "repository": "https://github.com/ihor-sokoliuk/mcp-searxng",
         "repositorySource": "github",
-        "stargazerCount": 1099
+        "stargazerCount": 1142
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.jagoff:memo",
       "displayName": "memo",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.9.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.12.2",
       "description": "Memory for AI agents — MLX (Apple Silicon) or CPU (Linux), sqlite-vec + BM25, zero cloud.",
       "tags": [
         "apple-silicon",
@@ -25239,14 +25369,14 @@
         "qwen",
         "rag"
       ],
-      "version": "4.9.3",
-      "updatedAt": "2026-08-06T13:08:14Z",
+      "version": "4.12.2",
+      "updatedAt": "2026-08-18T18:46:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
         "repository": "https://github.com/jagoff/memo",
         "repositorySource": "github",
-        "stargazerCount": 12
+        "stargazerCount": 13
       }
     },
     {
@@ -25256,7 +25386,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.0",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.0",
-      "updatedAt": "2026-08-06T13:08:16Z",
+      "updatedAt": "2026-08-18T18:46:57Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25269,7 +25399,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.mlava:agent-ready-mcp",
       "displayName": "Agent Ready",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fagent-ready-mcp/versions/0.7.2",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fagent-ready-mcp/versions/0.7.3",
       "description": "Scan any URL for AI agent readability — Vercel Spec, llmstxt.org, and agent-protocol manifests.",
       "tags": [
         "a2a",
@@ -25283,8 +25413,8 @@
         "mcp",
         "mcp-server-card"
       ],
-      "version": "0.7.2",
-      "updatedAt": "2026-08-06T13:08:24Z",
+      "version": "0.7.3",
+      "updatedAt": "2026-08-18T18:47:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25298,7 +25428,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.mlava:scholar-sidekick-mcp",
       "displayName": "Scholar Sidekick",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fscholar-sidekick-mcp/versions/0.8.7",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fscholar-sidekick-mcp/versions/0.8.8",
       "description": "Catch AI-fabricated citations (real DOI + fake title). Retraction, open-access, 10,000+ CSL styles.",
       "tags": [
         "academic",
@@ -25312,14 +25442,14 @@
         "doi",
         "mcp"
       ],
-      "version": "0.8.7",
-      "updatedAt": "2026-08-06T13:08:26Z",
+      "version": "0.8.8",
+      "updatedAt": "2026-08-18T18:47:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
         "repository": "https://github.com/mlava/scholar-sidekick-mcp",
         "repositorySource": "github",
-        "stargazerCount": 7,
+        "stargazerCount": 8,
         "websiteUrl": "https://scholar-sidekick.com/mcp"
       }
     },
@@ -25342,13 +25472,13 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-06T13:08:31Z",
+      "updatedAt": "2026-08-18T18:47:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
         "repository": "https://github.com/oleksiijko/pmb",
         "repositorySource": "github",
-        "stargazerCount": 283
+        "stargazerCount": 290
       }
     },
     {
@@ -25370,13 +25500,13 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:08:33Z",
+      "updatedAt": "2026-08-18T18:47:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
         "repository": "https://github.com/openaccountants/openaccountants",
         "repositorySource": "github",
-        "stargazerCount": 302
+        "stargazerCount": 329
       }
     },
     {
@@ -25386,7 +25516,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
       "version": "0.2.0",
-      "updatedAt": "2026-08-06T13:08:34Z",
+      "updatedAt": "2026-08-18T18:47:14Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -25398,25 +25528,42 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.parseablehq:parseable-mcp-server",
-      "displayName": "io.github.parseablehq/parseable-mcp-server",
+      "displayName": "Parseable",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.15",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
-      "version": "0.2.15",
-      "updatedAt": "2026-08-06T13:08:35Z",
+      "version": "0.2.16",
+      "updatedAt": "2026-08-18T18:47:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
         "repository": "https://github.com/parseablehq/parseable-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1
+        "stargazerCount": 4
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.patrickchugh:terravision",
+      "displayName": "TerraVision",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
+      "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
+      "version": "0.46.4",
+      "updatedAt": "2026-08-18T18:47:16Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
+        "repository": "https://github.com/patrickchugh/terravision",
+        "repositorySource": "github",
+        "stargazerCount": 1607,
+        "websiteUrl": "https://patrickchugh.github.io/terravision/"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.pete-builds:unifi",
       "displayName": "UniFi Gateway",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.pete-builds%2Funifi/versions/0.16.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.pete-builds%2Funifi/versions/0.21.1",
       "description": "Safe-by-default UniFi MCP: Network + Protect + Access, multi-site, dry-run, audit log.",
       "tags": [
         "docker",
@@ -25430,14 +25577,14 @@
         "unifi",
         "ucg-fiber"
       ],
-      "version": "0.16.1",
-      "updatedAt": "2026-08-06T13:08:36Z",
+      "version": "0.21.1",
+      "updatedAt": "2026-08-18T18:47:18Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
         "repository": "https://github.com/pete-builds/mcp-unifi",
         "repositorySource": "github",
-        "stargazerCount": 17,
+        "stargazerCount": 20,
         "websiteUrl": "https://pete-builds.github.io/mcp-unifi/"
       }
     },
@@ -25460,7 +25607,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-06T13:08:39Z",
+      "updatedAt": "2026-08-18T18:47:20Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -25470,12 +25617,12 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.quicknode:mcp",
-      "displayName": "io.github.quicknode/mcp",
+      "displayName": "Quicknode",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:08:42Z",
+      "updatedAt": "2026-08-18T18:47:22Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -25491,13 +25638,33 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-06T13:08:45Z",
+      "updatedAt": "2026-08-18T18:47:25Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
         "repository": "https://github.com/salahawad/outlook-personal-mcp",
         "repositorySource": "github",
         "stargazerCount": 1
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.sassoftware:sas-mcp-server",
+      "displayName": "SAS Viya",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.sassoftware%2Fsas-mcp-server/versions/1.10.0",
+      "description": "Execute SAS code and query Compute, CAS, and model APIs on SAS Viya via OAuth 2.0.",
+      "tags": [
+        "sas-aiml",
+        "sas-osp"
+      ],
+      "version": "1.10.0",
+      "updatedAt": "2026-08-18T18:47:27Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
+        "repository": "https://github.com/sassoftware/sas-mcp-server",
+        "repositorySource": "github",
+        "stargazerCount": 47
       }
     },
     {
@@ -25519,7 +25686,7 @@
         "x402"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-06T13:08:46Z",
+      "updatedAt": "2026-08-18T18:47:28Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
@@ -25530,13 +25697,41 @@
       }
     },
     {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.smaniches:semantic-scholar-mcp",
+      "displayName": "Semantic Scholar MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.smaniches%2Fsemantic-scholar-mcp/versions/1.7.2",
+      "description": "MCP server for the Semantic Scholar API: search 200M+ papers, citations, authors, recommendations.",
+      "tags": [
+        "academic-tool",
+        "claude",
+        "claude-ai",
+        "claude-code",
+        "mcp-server",
+        "research-tool",
+        "citation-graph",
+        "literature-review",
+        "model-context-protocol",
+        "semantic-scholar"
+      ],
+      "version": "1.7.2",
+      "updatedAt": "2026-08-18T18:47:30Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
+        "repository": "https://github.com/smaniches/semantic-scholar-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 13
+      }
+    },
+    {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.smythmyke:govtoolspro-mcp-server",
-      "displayName": "io.github.smythmyke/govtoolspro-mcp-server",
+      "displayName": "Smythmyke Govtoolspro",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-06T13:08:48Z",
+      "updatedAt": "2026-08-18T18:47:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -25553,7 +25748,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-06T13:08:49Z",
+      "updatedAt": "2026-08-18T18:47:32Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -25566,7 +25761,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.stackql:stackql-mcp",
       "displayName": "StackQL MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.stackql%2Fstackql-mcp/versions/0.10.591",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.stackql%2Fstackql-mcp/versions/0.10.601",
       "description": "SQL-native query and provisioning engine for cloud infrastructure, served over MCP.",
       "tags": [
         "asset-management",
@@ -25580,14 +25775,14 @@
         "sql",
         "stackql"
       ],
-      "version": "0.10.591",
-      "updatedAt": "2026-08-06T13:08:52Z",
+      "version": "0.10.601",
+      "updatedAt": "2026-08-18T18:47:34Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
         "repository": "https://github.com/stackql/stackql",
         "repositorySource": "github",
-        "stargazerCount": 866,
+        "stargazerCount": 867,
         "websiteUrl": "https://stackql.io"
       }
     },
@@ -25601,7 +25796,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:08:53Z",
+      "updatedAt": "2026-08-18T18:47:36Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -25615,27 +25810,28 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.uizze:uizze",
       "displayName": "UIZZE",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.uizze%2Fuizze/versions/1.1.20",
-      "description": "STOP UI SLOP. Free UI Slop Gate; full UIZZE adds 800K+ real screens, search, and finish gates.",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.uizze%2Fuizze/versions/1.2.11",
+      "description": "STOP UI SLOP. Free anti-ui-slop skill and UI Slop Gate for coding agents.",
       "tags": [
-        "ai-agents",
-        "mcp",
-        "model-context-protocol",
-        "ui-design",
-        "agentic-coding",
-        "mcp-server",
-        "ui-reference",
         "agent-skills",
-        "design-research",
-        "design-systems"
+        "claude-code",
+        "codex",
+        "cursor",
+        "frontend",
+        "ios-design",
+        "ui-design",
+        "design-systems",
+        "web-design",
+        "anti-ui-slop"
       ],
-      "version": "1.1.20",
-      "updatedAt": "2026-08-06T13:08:56Z",
+      "version": "1.2.11",
+      "updatedAt": "2026-08-18T18:47:38Z",
       "metadata": {
-        "readmeUrl": "https://github.com/uizze/uizze-mcp#readme",
-        "repository": "https://github.com/uizze/uizze-mcp",
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/uizze/uizze#readme",
+        "repository": "https://github.com/uizze/uizze",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 7,
         "websiteUrl": "https://uizze.com"
       }
     },
@@ -25658,12 +25854,12 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-06T13:09:02Z",
+      "updatedAt": "2026-08-18T18:47:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
         "repositorySource": "github",
-        "stargazerCount": 1230,
+        "stargazerCount": 1234,
         "websiteUrl": "https://docs.vybenetwork.com/docs/mcp"
       }
     },
@@ -25677,7 +25873,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-06T13:09:05Z",
+      "updatedAt": "2026-08-18T18:47:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -25688,18 +25884,34 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.zereight:gitlab-mcp",
-      "displayName": "io.github.zereight/gitlab-mcp",
+      "displayName": "Zereight Gitlab",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.46",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.49",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
-      "version": "2.1.46",
-      "updatedAt": "2026-08-06T13:09:06Z",
+      "version": "2.1.49",
+      "updatedAt": "2026-08-18T18:47:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
         "repository": "https://github.com/zereight/gitlab-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1880
+        "stargazerCount": 1897
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.mediawork:mediawork",
+      "displayName": "Mediawork",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
+      "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
+      "version": "0.1.1",
+      "updatedAt": "2026-08-18T18:47:50Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
+        "repository": "https://github.com/screen-arts/mediawork-mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://www.mediawork.io"
       }
     },
     {
@@ -25721,7 +25933,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-06T13:09:09Z",
+      "updatedAt": "2026-08-18T18:47:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -25737,12 +25949,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-06T13:09:13Z",
+      "updatedAt": "2026-08-18T18:47:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
         "repository": "https://github.com/Unstructured-IO/unstructured-mcp-integrations",
         "repositorySource": "github",
+        "stargazerCount": 1,
         "websiteUrl": "https://docs.unstructured.io/transform/overview"
       }
     },
@@ -25750,7 +25963,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:one.faf:claude-faf-mcp",
       "displayName": "Claude FAF",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/one.faf%2Fclaude-faf-mcp/versions/5.20.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/one.faf%2Fclaude-faf-mcp/versions/5.22.0",
       "description": "Persistent project context for Claude. IANA-registered .faf format.",
       "tags": [
         "ai",
@@ -25764,14 +25977,14 @@
         "mcp-server",
         "model-context-protocol"
       ],
-      "version": "5.20.0",
-      "updatedAt": "2026-08-06T13:09:21Z",
+      "version": "5.22.0",
+      "updatedAt": "2026-08-18T18:47:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
         "repository": "https://github.com/Wolfe-Jam/claude-faf-mcp",
         "repositorySource": "github",
-        "stargazerCount": 21,
+        "stargazerCount": 22,
         "websiteUrl": "https://faf.one"
       }
     },
@@ -25794,7 +26007,7 @@
         "typescript"
       ],
       "version": "2.3.1",
-      "updatedAt": "2026-08-06T13:09:22Z",
+      "updatedAt": "2026-08-18T18:47:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -25806,10 +26019,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:org.sylin:ghostlight",
-      "displayName": "org.sylin/ghostlight",
+      "displayName": "Sylin Ghostlight",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/0.7.3",
-      "description": "Drive your real logged-in browser from any MCP client. Governed or wide open, one portable binary.",
+      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/0.8.0",
+      "description": "Visible local browser automation in signed-in Chromium, with optional policy and audit.",
       "tags": [
         "access-control",
         "ai-agents",
@@ -25822,14 +26035,44 @@
         "model-context-protocol",
         "rust"
       ],
-      "version": "0.7.3",
-      "updatedAt": "2026-08-06T13:09:23Z",
+      "version": "0.8.0",
+      "updatedAt": "2026-08-18T18:47:58Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
         "repository": "https://github.com/sylin-org/ghostlight",
         "repositorySource": "github",
+        "stargazerCount": 1,
         "websiteUrl": "https://sylin.org/ghostlight/"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:pl.gamedev:creator",
+      "displayName": "gamedev.pl",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/pl.gamedev%2Fcreator/versions/1.0.1",
+      "description": "Build browser games on gamedev.pl from your coding agent.",
+      "tags": [
+        "gamedev",
+        "ai",
+        "ai-agents",
+        "browser-games",
+        "fastify",
+        "game-development",
+        "multiplayer",
+        "party-games",
+        "react",
+        "typescript"
+      ],
+      "version": "1.0.1",
+      "updatedAt": "2026-08-18T18:48:00Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
+        "repository": "https://github.com/gamedevpl/www.gamedev.pl",
+        "repositorySource": "github",
+        "stargazerCount": 7,
+        "websiteUrl": "https://www.gamedev.pl"
       }
     },
     {
@@ -25839,7 +26082,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-06T13:09:25Z",
+      "updatedAt": "2026-08-18T18:48:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -23378,7 +23378,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:44:10Z",
+      "updatedAt": "2026-08-18T20:05:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -23393,7 +23393,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-18T18:44:11Z",
+      "updatedAt": "2026-08-18T20:05:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -23418,7 +23418,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-08-18T18:44:12Z",
+      "updatedAt": "2026-08-18T20:06:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -23433,7 +23433,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-18T18:44:14Z",
+      "updatedAt": "2026-08-18T20:06:01Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -23457,7 +23457,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-18T18:44:15Z",
+      "updatedAt": "2026-08-18T20:06:02Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -23484,7 +23484,7 @@
         "claude-code"
       ],
       "version": "1.14.1",
-      "updatedAt": "2026-08-18T18:44:16Z",
+      "updatedAt": "2026-08-18T20:06:03Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -23508,7 +23508,7 @@
         "model-context-protocol"
       ],
       "version": "0.9.1",
-      "updatedAt": "2026-08-18T18:44:17Z",
+      "updatedAt": "2026-08-18T20:06:04Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -23536,7 +23536,7 @@
         "mcp-server"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-18T18:44:19Z",
+      "updatedAt": "2026-08-18T20:06:06Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -23553,7 +23553,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-18T18:44:20Z",
+      "updatedAt": "2026-08-18T20:06:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -23579,7 +23579,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-18T18:44:21Z",
+      "updatedAt": "2026-08-18T20:06:08Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
@@ -23603,7 +23603,7 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:22Z",
+      "updatedAt": "2026-08-18T20:06:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
@@ -23619,7 +23619,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:44:23Z",
+      "updatedAt": "2026-08-18T20:06:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -23646,7 +23646,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-18T18:44:24Z",
+      "updatedAt": "2026-08-18T20:06:11Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -23674,7 +23674,7 @@
         "mcp"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-18T18:44:25Z",
+      "updatedAt": "2026-08-18T20:06:12Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -23703,7 +23703,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-18T18:44:27Z",
+      "updatedAt": "2026-08-18T20:06:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -23720,7 +23720,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-18T18:44:31Z",
+      "updatedAt": "2026-08-18T20:06:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -23735,7 +23735,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:32Z",
+      "updatedAt": "2026-08-18T20:06:19Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23751,7 +23751,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:33Z",
+      "updatedAt": "2026-08-18T20:06:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23767,7 +23767,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:44:34Z",
+      "updatedAt": "2026-08-18T20:06:21Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23783,7 +23783,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:44:35Z",
+      "updatedAt": "2026-08-18T20:06:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23799,7 +23799,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:44:36Z",
+      "updatedAt": "2026-08-18T20:06:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23815,7 +23815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:37Z",
+      "updatedAt": "2026-08-18T20:06:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23831,7 +23831,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:38Z",
+      "updatedAt": "2026-08-18T20:06:25Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23847,7 +23847,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-18T18:44:39Z",
+      "updatedAt": "2026-08-18T20:06:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23861,7 +23861,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-18T18:44:40Z",
+      "updatedAt": "2026-08-18T20:06:27Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -23887,7 +23887,7 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-08-18T18:44:41Z",
+      "updatedAt": "2026-08-18T20:06:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
@@ -23915,7 +23915,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-18T18:44:42Z",
+      "updatedAt": "2026-08-18T20:06:29Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23932,7 +23932,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.2",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.2",
-      "updatedAt": "2026-08-18T18:44:43Z",
+      "updatedAt": "2026-08-18T20:06:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23957,7 +23957,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-18T18:44:46Z",
+      "updatedAt": "2026-08-18T20:06:33Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -23973,7 +23973,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-18T18:44:47Z",
+      "updatedAt": "2026-08-18T20:06:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -23997,7 +23997,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:50Z",
+      "updatedAt": "2026-08-18T20:06:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -24013,7 +24013,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-18T18:44:52Z",
+      "updatedAt": "2026-08-18T20:06:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -24040,7 +24040,7 @@
         "technical-drawing"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-18T18:44:54Z",
+      "updatedAt": "2026-08-18T20:06:39Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -24064,7 +24064,7 @@
         "trading"
       ],
       "version": "0.8.7",
-      "updatedAt": "2026-08-18T18:44:55Z",
+      "updatedAt": "2026-08-18T20:06:40Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -24084,7 +24084,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-18T18:44:56Z",
+      "updatedAt": "2026-08-18T20:06:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -24111,7 +24111,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:44:57Z",
+      "updatedAt": "2026-08-18T20:06:42Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -24137,7 +24137,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-18T18:44:58Z",
+      "updatedAt": "2026-08-18T20:06:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
@@ -24163,7 +24163,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-18T18:44:59Z",
+      "updatedAt": "2026-08-18T20:06:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -24182,7 +24182,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:45:05Z",
+      "updatedAt": "2026-08-18T20:06:51Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -24204,7 +24204,7 @@
         "sports-betting"
       ],
       "version": "1.4.3",
-      "updatedAt": "2026-08-18T18:45:09Z",
+      "updatedAt": "2026-08-18T20:06:53Z",
       "metadata": {
         "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
         "repository": "https://github.com/negative-ev/negativeev-mcp",
@@ -24219,7 +24219,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-18T18:45:10Z",
+      "updatedAt": "2026-08-18T20:06:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -24234,7 +24234,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-18T18:45:12Z",
+      "updatedAt": "2026-08-18T20:06:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -24261,7 +24261,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-18T18:45:15Z",
+      "updatedAt": "2026-08-18T20:06:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -24287,7 +24287,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-18T18:45:16Z",
+      "updatedAt": "2026-08-18T20:07:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -24303,7 +24303,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.47.27",
-      "updatedAt": "2026-08-18T18:45:17Z",
+      "updatedAt": "2026-08-18T20:07:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -24330,7 +24330,7 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-08-18T18:45:21Z",
+      "updatedAt": "2026-08-18T20:07:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -24349,7 +24349,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-18T18:45:23Z",
+      "updatedAt": "2026-08-18T20:07:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -24366,7 +24366,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.1.2",
-      "updatedAt": "2026-08-18T18:45:29Z",
+      "updatedAt": "2026-08-18T20:07:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -24394,7 +24394,7 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-18T18:45:33Z",
+      "updatedAt": "2026-08-18T20:07:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
@@ -24420,7 +24420,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-18T18:45:34Z",
+      "updatedAt": "2026-08-18T20:07:18Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -24448,7 +24448,7 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-18T18:45:36Z",
+      "updatedAt": "2026-08-18T20:07:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
@@ -24475,7 +24475,7 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-18T18:45:37Z",
+      "updatedAt": "2026-08-18T20:07:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
@@ -24501,7 +24501,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-08-18T18:45:38Z",
+      "updatedAt": "2026-08-18T20:07:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -24517,7 +24517,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-18T18:45:40Z",
+      "updatedAt": "2026-08-18T20:07:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -24533,7 +24533,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-18T18:45:41Z",
+      "updatedAt": "2026-08-18T20:07:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -24561,7 +24561,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-18T18:45:44Z",
+      "updatedAt": "2026-08-18T20:07:26Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24589,7 +24589,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-18T18:45:45Z",
+      "updatedAt": "2026-08-18T20:07:28Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24618,7 +24618,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:45:46Z",
+      "updatedAt": "2026-08-18T20:07:29Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24647,7 +24647,7 @@
         "ai-native"
       ],
       "version": "1.16.3",
-      "updatedAt": "2026-08-18T18:45:47Z",
+      "updatedAt": "2026-08-18T20:07:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24675,7 +24675,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-18T18:45:48Z",
+      "updatedAt": "2026-08-18T20:07:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24692,7 +24692,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-18T18:45:50Z",
+      "updatedAt": "2026-08-18T20:07:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24707,7 +24707,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.4.1",
-      "updatedAt": "2026-08-18T18:45:53Z",
+      "updatedAt": "2026-08-18T20:07:49Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
@@ -24724,7 +24724,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-18T18:45:54Z",
+      "updatedAt": "2026-08-18T20:07:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
@@ -24752,7 +24752,7 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-18T18:45:57Z",
+      "updatedAt": "2026-08-18T20:08:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
@@ -24778,7 +24778,7 @@
         "scaffolding"
       ],
       "version": "15.5.1",
-      "updatedAt": "2026-08-18T18:45:59Z",
+      "updatedAt": "2026-08-18T20:08:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24806,7 +24806,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-18T18:46:00Z",
+      "updatedAt": "2026-08-18T20:08:23Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24822,7 +24822,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-08-18T18:46:01Z",
+      "updatedAt": "2026-08-18T20:08:30Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
@@ -24851,7 +24851,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:46:02Z",
+      "updatedAt": "2026-08-18T20:08:36Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -24879,7 +24879,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-18T18:46:04Z",
+      "updatedAt": "2026-08-18T20:08:42Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24898,7 +24898,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:46:05Z",
+      "updatedAt": "2026-08-18T20:08:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24913,7 +24913,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
       "version": "0.8.0",
-      "updatedAt": "2026-08-18T18:46:06Z",
+      "updatedAt": "2026-08-18T20:03:34Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
@@ -24942,7 +24942,7 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.9",
-      "updatedAt": "2026-08-18T18:46:08Z",
+      "updatedAt": "2026-08-18T20:03:36Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
@@ -24959,7 +24959,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-18T18:46:09Z",
+      "updatedAt": "2026-08-18T20:03:37Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24975,7 +24975,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.SEKeener%2Fairtreks-mcp/versions/1.0.2",
       "description": "Multi-city flight routing intelligence — plan RTW trips, validate alliances, get carrier picks.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-18T18:46:12Z",
+      "updatedAt": "2026-08-18T20:03:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SEKeener/airtreks-mcp#readme",
@@ -25004,7 +25004,7 @@
         "mcp-tools"
       ],
       "version": "1.6.0",
-      "updatedAt": "2026-08-18T18:46:14Z",
+      "updatedAt": "2026-08-18T20:03:42Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
@@ -25033,7 +25033,7 @@
         "a2a-protocol"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-08-18T18:46:20Z",
+      "updatedAt": "2026-08-18T20:03:47Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -25057,7 +25057,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-18T18:46:22Z",
+      "updatedAt": "2026-08-18T20:03:49Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -25085,7 +25085,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-18T18:46:23Z",
+      "updatedAt": "2026-08-18T20:03:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -25113,7 +25113,7 @@
         "ai-agents"
       ],
       "version": "0.16.0",
-      "updatedAt": "2026-08-18T18:46:25Z",
+      "updatedAt": "2026-08-18T20:03:51Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -25142,7 +25142,7 @@
         "ai-tools"
       ],
       "version": "0.4.0",
-      "updatedAt": "2026-08-18T18:46:26Z",
+      "updatedAt": "2026-08-18T20:03:52Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -25171,7 +25171,7 @@
         "knowlege-graph"
       ],
       "version": "0.22.1",
-      "updatedAt": "2026-08-18T18:46:28Z",
+      "updatedAt": "2026-08-18T20:03:55Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
@@ -25199,7 +25199,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-18T18:46:33Z",
+      "updatedAt": "2026-08-18T20:04:00Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -25228,7 +25228,7 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-18T18:46:35Z",
+      "updatedAt": "2026-08-18T20:04:01Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
@@ -25245,7 +25245,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-18T18:46:37Z",
+      "updatedAt": "2026-08-18T20:04:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25273,7 +25273,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.3",
-      "updatedAt": "2026-08-18T18:46:38Z",
+      "updatedAt": "2026-08-18T20:04:04Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -25289,7 +25289,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-08-18T18:46:42Z",
+      "updatedAt": "2026-08-18T20:04:09Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -25314,7 +25314,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.42.0",
-      "updatedAt": "2026-08-18T18:46:50Z",
+      "updatedAt": "2026-08-18T20:04:16Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
@@ -25342,7 +25342,7 @@
         "privacy"
       ],
       "version": "1.15.0",
-      "updatedAt": "2026-08-18T18:46:52Z",
+      "updatedAt": "2026-08-18T20:04:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
@@ -25370,7 +25370,7 @@
         "rag"
       ],
       "version": "4.12.2",
-      "updatedAt": "2026-08-18T18:46:54Z",
+      "updatedAt": "2026-08-18T20:04:20Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
@@ -25386,7 +25386,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.0",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.0",
-      "updatedAt": "2026-08-18T18:46:57Z",
+      "updatedAt": "2026-08-18T20:04:23Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25414,7 +25414,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.3",
-      "updatedAt": "2026-08-18T18:47:06Z",
+      "updatedAt": "2026-08-18T20:04:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25443,7 +25443,7 @@
         "mcp"
       ],
       "version": "0.8.8",
-      "updatedAt": "2026-08-18T18:47:07Z",
+      "updatedAt": "2026-08-18T20:04:32Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -25472,7 +25472,7 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-18T18:47:12Z",
+      "updatedAt": "2026-08-18T20:04:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
@@ -25500,7 +25500,7 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:47:13Z",
+      "updatedAt": "2026-08-18T20:04:38Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
@@ -25516,7 +25516,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
       "version": "0.2.0",
-      "updatedAt": "2026-08-18T18:47:14Z",
+      "updatedAt": "2026-08-18T20:04:39Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -25533,7 +25533,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-08-18T18:47:15Z",
+      "updatedAt": "2026-08-18T20:04:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -25549,7 +25549,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.46.4",
-      "updatedAt": "2026-08-18T18:47:16Z",
+      "updatedAt": "2026-08-18T20:04:41Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
@@ -25578,7 +25578,7 @@
         "ucg-fiber"
       ],
       "version": "0.21.1",
-      "updatedAt": "2026-08-18T18:47:18Z",
+      "updatedAt": "2026-08-18T20:04:43Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
@@ -25607,7 +25607,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-18T18:47:20Z",
+      "updatedAt": "2026-08-18T20:04:45Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -25622,7 +25622,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:47:22Z",
+      "updatedAt": "2026-08-18T20:04:47Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -25638,7 +25638,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-18T18:47:25Z",
+      "updatedAt": "2026-08-18T20:04:50Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -25658,7 +25658,7 @@
         "sas-osp"
       ],
       "version": "1.10.0",
-      "updatedAt": "2026-08-18T18:47:27Z",
+      "updatedAt": "2026-08-18T20:04:51Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
@@ -25686,7 +25686,7 @@
         "x402"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-18T18:47:28Z",
+      "updatedAt": "2026-08-18T20:04:52Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
@@ -25715,7 +25715,7 @@
         "semantic-scholar"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-18T18:47:30Z",
+      "updatedAt": "2026-08-18T20:04:55Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
@@ -25731,7 +25731,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-18T18:47:31Z",
+      "updatedAt": "2026-08-18T20:04:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -25748,7 +25748,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-18T18:47:32Z",
+      "updatedAt": "2026-08-18T20:04:57Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -25776,7 +25776,7 @@
         "stackql"
       ],
       "version": "0.10.601",
-      "updatedAt": "2026-08-18T18:47:34Z",
+      "updatedAt": "2026-08-18T20:04:59Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
@@ -25796,7 +25796,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:47:36Z",
+      "updatedAt": "2026-08-18T20:05:00Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -25825,7 +25825,7 @@
         "anti-ui-slop"
       ],
       "version": "1.2.11",
-      "updatedAt": "2026-08-18T18:47:38Z",
+      "updatedAt": "2026-08-18T20:05:02Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
@@ -25854,7 +25854,7 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-18T18:47:43Z",
+      "updatedAt": "2026-08-18T20:05:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
@@ -25873,7 +25873,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-18T18:47:45Z",
+      "updatedAt": "2026-08-18T20:05:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -25889,13 +25889,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.49",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
       "version": "2.1.49",
-      "updatedAt": "2026-08-18T18:47:46Z",
+      "updatedAt": "2026-08-18T20:05:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
         "repository": "https://github.com/zereight/gitlab-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1897
+        "stargazerCount": 1896
       }
     },
     {
@@ -25905,7 +25905,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
       "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-18T18:47:50Z",
+      "updatedAt": "2026-08-18T20:05:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -25933,7 +25933,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-18T18:47:51Z",
+      "updatedAt": "2026-08-18T20:05:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -25949,7 +25949,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-18T18:47:55Z",
+      "updatedAt": "2026-08-18T20:05:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -25978,7 +25978,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.0",
-      "updatedAt": "2026-08-18T18:47:56Z",
+      "updatedAt": "2026-08-18T20:05:19Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -26007,7 +26007,7 @@
         "typescript"
       ],
       "version": "2.3.1",
-      "updatedAt": "2026-08-18T18:47:57Z",
+      "updatedAt": "2026-08-18T20:05:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -26036,7 +26036,7 @@
         "rust"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-08-18T18:47:58Z",
+      "updatedAt": "2026-08-18T20:05:22Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -26065,7 +26065,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:48:00Z",
+      "updatedAt": "2026-08-18T20:05:23Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -26082,7 +26082,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-18T18:48:01Z",
+      "updatedAt": "2026-08-18T20:05:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",

--- a/scripts/generate_ai_catalog.py
+++ b/scripts/generate_ai_catalog.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 from urllib.error import URLError
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 SCRIPT = Path(__file__).resolve()
@@ -14,6 +14,8 @@ OUTPUT = ROOT / "ai-catalog.json"
 MAX_ENTRIES = 10_000
 MAX_BYTES = 10 * 1024 * 1024
 MCP_CATALOG = "https://api.mcp.github.com/.well-known/ai-catalog.json"
+MCP_REGISTRY = "https://api.mcp.github.com/v0.1/servers"
+MCP_REGISTRY_PAGE_SIZE = 100
 
 
 def fail(message):
@@ -65,6 +67,62 @@ def load_mcp_entries():
     return document["entries"]
 
 
+def load_mcp_registry_records():
+    records = []
+    cursor = None
+    while True:
+        query = {"limit": MCP_REGISTRY_PAGE_SIZE}
+        if cursor:
+            query["cursor"] = cursor
+        url = f"{MCP_REGISTRY}?{urlencode(query)}"
+        try:
+            request = Request(url, headers={"User-Agent": "agentfinder-catalog-generator"})
+            with urlopen(request, timeout=30) as response:
+                document = json.load(response)
+        except (OSError, URLError, json.JSONDecodeError) as error:
+            fail(f"{MCP_REGISTRY}: {error}")
+        if not isinstance(document, dict) or not isinstance(document.get("servers"), list):
+            fail(f"{url}: expected a registry document with a servers array")
+        records.extend(document["servers"])
+        metadata = document.get("metadata")
+        cursor = metadata.get("nextCursor") if isinstance(metadata, dict) else None
+        if not cursor:
+            return records
+
+
+def registry_record_key(entry):
+    url = entry.get("url")
+    if not isinstance(url, str):
+        return None
+    path = [unquote(part) for part in urlparse(url).path.split("/") if part]
+    try:
+        servers_index = path.index("servers")
+        return path[servers_index + 1], path[servers_index + 3]
+    except (ValueError, IndexError):
+        return None
+
+
+def display_name(entry, registry_record=None):
+    server = registry_record.get("server", {}) if isinstance(registry_record, dict) else {}
+    if not isinstance(server, dict):
+        server = {}
+    metadata = server.get("_meta", {})
+    publisher = (
+        metadata.get("io.modelcontextprotocol.registry/publisher-provided", {})
+        if isinstance(metadata, dict)
+        else {}
+    )
+    github = publisher.get("github", {}) if isinstance(publisher, dict) else {}
+    candidates = (
+        github.get("displayName"),
+        server.get("title"),
+        entry.get("title"),
+        entry.get("displayName"),
+        entry.get("name"),
+    )
+    return next((value for value in candidates if isinstance(value, str) and value.strip()), None)
+
+
 def generate():
     entries = []
     identities = set()
@@ -98,11 +156,24 @@ def generate():
         load_mcp_entries(),
         key=lambda entry: (str(entry.get("identifier")), str(entry.get("version"))),
     )
+    registry_records = {
+        (record["server"].get("name"), record["server"].get("version")): record
+        for record in load_mcp_registry_records()
+        if isinstance(record, dict)
+        and isinstance(record.get("server"), dict)
+        and isinstance(record["server"].get("name"), str)
+        and isinstance(record["server"].get("version"), str)
+    } if remote_entries else {}
     for index, entry in enumerate(remote_entries):
         source = f"{MCP_CATALOG} entry {index}"
         validate(entry, source)
         if entry["identifier"] not in local_identifiers:
-            add(entry, source)
+            generated = dict(entry)
+            record = registry_records.get(registry_record_key(entry))
+            name = display_name(entry, record)
+            if name:
+                generated["displayName"] = name
+            add(generated, source)
 
     if len(entries) > MAX_ENTRIES:
         fail(f"catalog has {len(entries)} entries; limit is {MAX_ENTRIES}")

--- a/scripts/generate_ai_catalog.py
+++ b/scripts/generate_ai_catalog.py
@@ -113,6 +113,8 @@ def display_name(entry, registry_record=None):
         else {}
     )
     github = publisher.get("github", {}) if isinstance(publisher, dict) else {}
+    if not isinstance(github, dict):
+        github = {}
     candidates = (
         github.get("displayName"),
         server.get("title"),

--- a/tests/test_generate_ai_catalog.py
+++ b/tests/test_generate_ai_catalog.py
@@ -8,6 +8,47 @@ from scripts import generate_ai_catalog
 
 
 class ValidateEntryTest(unittest.TestCase):
+    def test_display_name_precedence(self):
+        entry = {"displayName": "owner/repo", "title": "Catalog title", "name": "server-name"}
+        registry_record = {
+            "server": {
+                "title": "Registry title",
+                "_meta": {
+                    "io.modelcontextprotocol.registry/publisher-provided": {
+                        "github": {"displayName": "GitHub display name"}
+                    }
+                },
+            }
+        }
+        self.assertEqual(
+            generate_ai_catalog.display_name(entry, registry_record),
+            "GitHub display name",
+        )
+        self.assertEqual(
+            generate_ai_catalog.display_name(entry, {"server": {"title": "Registry title"}}),
+            "Registry title",
+        )
+        self.assertEqual(
+            generate_ai_catalog.display_name(entry, {}),
+            "Catalog title",
+        )
+        self.assertEqual(
+            generate_ai_catalog.display_name({"displayName": "owner/repo"}, {}),
+            "owner/repo",
+        )
+
+    def test_registry_record_key_from_version_url(self):
+        entry = {
+            "url": (
+                "https://api.mcp.github.com/v0.1/servers/"
+                "microsoft%2Fmarkitdown/versions/1.0.0"
+            )
+        }
+        self.assertEqual(
+            generate_ai_catalog.registry_record_key(entry),
+            ("microsoft/markitdown", "1.0.0"),
+        )
+
     def test_url_or_data(self):
         entry = {
             "identifier": "urn:ai:example.com:test:item",
@@ -49,6 +90,59 @@ class ValidateEntryTest(unittest.TestCase):
                 rendered, _ = generate_ai_catalog.generate()
 
         self.assertEqual(json.loads(rendered)["entries"][0]["type"], "application/example")
+
+    def test_generated_mcp_entry_uses_registry_github_display_name(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "catalog" / "example"
+            source.mkdir(parents=True)
+            (source / "item.json").write_text(
+                json.dumps(
+                    {
+                        "identifier": "urn:ai:example.com:test:item",
+                        "displayName": "Test",
+                        "type": "application/example",
+                        "url": "https://example.com",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            remote = {
+                "identifier": "urn:ai:registry.modelcontextprotocol.io:owner:repo",
+                "displayName": "owner/repo",
+                "type": "application/mcp-server+json",
+                "url": (
+                    "https://api.mcp.github.com/v0.1/servers/"
+                    "owner%2Frepo/versions/1.0.0"
+                ),
+                "version": "1.0.0",
+            }
+            registry_record = {
+                "server": {
+                    "name": "owner/repo",
+                    "version": "1.0.0",
+                    "title": "Registry title",
+                    "_meta": {
+                        "io.modelcontextprotocol.registry/publisher-provided": {
+                            "github": {"displayName": "Publisher display name"}
+                        }
+                    },
+                }
+            }
+            with (
+                patch.object(generate_ai_catalog, "ROOT", root),
+                patch.object(generate_ai_catalog, "SOURCE_DIR", root / "catalog"),
+                patch.object(generate_ai_catalog, "load_mcp_entries", return_value=[remote]),
+                patch.object(
+                    generate_ai_catalog,
+                    "load_mcp_registry_records",
+                    return_value=[registry_record],
+                ),
+            ):
+                rendered, _ = generate_ai_catalog.generate()
+
+        entries = json.loads(rendered)["entries"]
+        self.assertEqual(entries[1]["displayName"], "Publisher display name")
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_ai_catalog.py
+++ b/tests/test_generate_ai_catalog.py
@@ -30,6 +30,22 @@ class ValidateEntryTest(unittest.TestCase):
             "Registry title",
         )
         self.assertEqual(
+            generate_ai_catalog.display_name(
+                entry,
+                {
+                    "server": {
+                        "title": "Registry title",
+                        "_meta": {
+                            "io.modelcontextprotocol.registry/publisher-provided": {
+                                "github": None,
+                            }
+                        },
+                    }
+                },
+            ),
+            "Registry title",
+        )
+        self.assertEqual(
             generate_ai_catalog.display_name(entry, {}),
             "Catalog title",
         )

--- a/tests/test_generate_ai_catalog.py
+++ b/tests/test_generate_ai_catalog.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
 from scripts import generate_ai_catalog
@@ -143,6 +144,49 @@ class ValidateEntryTest(unittest.TestCase):
 
         entries = json.loads(rendered)["entries"]
         self.assertEqual(entries[1]["displayName"], "Publisher display name")
+
+    def test_load_mcp_registry_records_paginates_with_next_cursor(self):
+        class FakeResponse:
+            def __init__(self, payload):
+                self.payload = json.dumps(payload).encode("utf-8")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return self.payload
+
+        first_page = {
+            "servers": [{"server": {"name": "alpha", "version": "1.0.0"}}],
+            "metadata": {"nextCursor": "page-two"},
+        }
+        second_page = {
+            "servers": [{"server": {"name": "beta", "version": "2.0.0"}}],
+            "metadata": {},
+        }
+        with patch.object(
+            generate_ai_catalog,
+            "urlopen",
+            side_effect=[FakeResponse(first_page), FakeResponse(second_page)],
+        ) as mocked_urlopen:
+            records = generate_ai_catalog.load_mcp_registry_records()
+
+        self.assertEqual(
+            records,
+            [
+                {"server": {"name": "alpha", "version": "1.0.0"}},
+                {"server": {"name": "beta", "version": "2.0.0"}},
+            ],
+        )
+        self.assertEqual(mocked_urlopen.call_count, 2)
+
+        first_url = mocked_urlopen.call_args_list[0].args[0].full_url
+        second_url = mocked_urlopen.call_args_list[1].args[0].full_url
+        self.assertEqual(parse_qs(urlparse(first_url).query), {"limit": ["100"]})
+        self.assertEqual(parse_qs(urlparse(second_url).query), {"limit": ["100"], "cursor": ["page-two"]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR fixes the remote MCP display-name issue in the generated AI catalog by honoring the registry's publisher-provided GitHub metadata before falling back to the title or the existing name.

The precedence is:

1. `_meta["io.modelcontextprotocol.registry/publisher-provided"].github.displayName`
2. registry/catalog `title`
3. existing entry `displayName` or `name` fallback

This is limited to the AI catalog generation path; Agent Finder itself is unchanged.

The generated catalog file in this branch is refreshed from the current live upstream data, so it may also include normal registry-driven updates (for example, server version bumps, description refreshes, and entries added/removed upstream). Those are part of the catalog sync refresh and are included here for transparency; the functional fix in scope is the display-name precedence behavior and its tests.

This continues the catalog sync work started in [github/agentfinder#238](https://github.com/github/agentfinder/pull/238): keeping the generated catalog aligned with registry metadata rather than exposing raw slugs when a publisher-supplied GitHub display name is available.

## References

- Published AI catalog: https://api.mcp.github.com/.well-known/ai-catalog.json
- MCP registry API: https://api.mcp.github.com/v0.1/servers
- Registry record example: https://api.mcp.github.com/v0.1/servers/microsoft%2Fmarkitdown/versions/1.0.0