### PR TITLE
Add canvas-only plugins to catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,9 @@ Create a file at `catalog/<your-publisher>/<augment-name>.json` with the followi
   "mediaType": "application/ai-skill",
   "url": "https://github.com/<publisher>/<repo>/blob/main/path/to/SKILL.md",
   "description": "A short description of what this augment does.",
+  "tags": [
+    "optional-tag"
+  ],
   "metadata": {
     "sourceSet": "<repo>",
     "repoPath": "path/to/SKILL.md"
@@ -56,8 +59,27 @@ Create a file at `catalog/<your-publisher>/<augment-name>.json` with the followi
 | `mediaType` | ✅ | The type of augment (e.g., `application/ai-skill`) |
 | `url` | ✅ | URL to the augment's definition file (e.g., SKILL.md) |
 | `description` | ✅ | A brief description of the augment's purpose |
+| `tags` | ❌ | Tags used to categorize and filter the augment |
 | `metadata.sourceSet` | ✅ | The source repository name |
 | `metadata.repoPath` | ✅ | Path to the definition file within the repository |
+
+#### Canvas-only plugins
+
+Catalog entries for plugins whose functionality consists entirely of a GitHub Copilot
+canvas keep the `application/vnd.github.copilot-plugin` media type and must include all
+of these tags:
+
+```json
+"tags": [
+  "canvas",
+  "canvas-only",
+  "github-copilot"
+]
+```
+
+Do not use `canvas-only` for a plugin that still provides useful agents, skills, hooks,
+or MCP servers when its canvas is unavailable. Canvas-only entries must not include
+the corresponding `agent`, `skill`, `hook`, or `mcp-server` capability tags.
 
 ### 4. Validate your JSON
 

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -6209,6 +6209,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:accessibility-kanban",
+      "displayName": "Accessibility Kanban",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/accessibility-kanban/plugin.json",
+      "description": "Kanban board to manage accessibility issues and plan, track, and complete remediation work.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/accessibility-kanban/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:acquire-codebase-knowledge",
       "displayName": "Acquire Codebase Knowledge",
       "mediaType": "application/ai-skill",
@@ -6425,6 +6442,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:apng-studio",
+      "displayName": "APNG Studio",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/apng-studio/plugin.json",
+      "description": "Build Animated PNG files in an interactive GitHub Copilot canvas by drawing or uploading frames, tuning animation settings, previewing, and exporting.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/apng-studio/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:appinsights-instrumentation",
       "displayName": "Appinsights Instrumentation",
       "mediaType": "application/ai-skill",
@@ -6447,6 +6481,23 @@
         "repoPath": "skills/apple-appstore-reviewer/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:arcade-canvas",
+      "displayName": "Arcade Canvas",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/arcade-canvas/plugin.json",
+      "description": "Play five retro Phaser mini-games in a GitHub Copilot canvas while agents work.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/arcade-canvas/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:arch-linux-triage",
@@ -6869,6 +6920,40 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:backlog-swipe-triage",
+      "displayName": "Backlog Swipe Triage",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/backlog-swipe-triage/plugin.json",
+      "description": "Swipe through backlog issues in a GitHub Copilot canvas to assign, request information, defer, close, or ignore them.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/backlog-swipe-triage/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:backrooms-canvas",
+      "displayName": "Backrooms Canvas",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/backrooms-canvas/plugin.json",
+      "description": "Wander an endless first-person backrooms in a GitHub Copilot canvas while agent status is ghost-written on the walls.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/backrooms-canvas/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:batch-files",
       "displayName": "Batch Files",
       "mediaType": "application/ai-skill",
@@ -7025,6 +7110,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:chat-cards",
+      "displayName": "Chat Cards",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/chat-cards/plugin.json",
+      "description": "Present interactive cards, tables, charts, forms, documents, and videos in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/chat-cards/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:chrome-devtools",
       "displayName": "Chrome Devtools",
       "mediaType": "application/ai-skill",
@@ -7035,6 +7137,23 @@
         "repoPath": "skills/chrome-devtools/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:chromium-control-canvas",
+      "displayName": "Chromium Control Canvas",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/chromium-control-canvas/plugin.json",
+      "description": "Navigate and interact with a real Chromium window through a GitHub Copilot canvas control panel and agent actions.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/chromium-control-canvas/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:cli-mastery",
@@ -7107,6 +7226,23 @@
         "repoPath": "skills/codeql/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:color-orb",
+      "displayName": "Color Orb",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/color-orb/plugin.json",
+      "description": "Interact with an agent-controlled color orb and live activity log in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/color-orb/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:comment-code-generate-a-tutorial",
@@ -7793,6 +7929,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:diagram-viewer",
+      "displayName": "Diagram Viewer",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/diagram-viewer/plugin.json",
+      "description": "Render interactive diagrams, drill into nodes, and view agent-generated explanations in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/diagram-viewer/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:doc-and-modernize",
       "displayName": "Doc and Modernize",
       "mediaType": "application/ai-skill",
@@ -8057,6 +8210,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:feedback-themes",
+      "displayName": "Feedback Themes",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/feedback-themes/plugin.json",
+      "description": "Explore grouped customer feedback signals by impact and drill into themes in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/feedback-themes/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:finalize-agent-prompt",
       "displayName": "Finalize Agent Prompt",
       "mediaType": "application/ai-skill",
@@ -8091,6 +8261,23 @@
         "repoPath": "skills/first-ask/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:flight-map-canvas",
+      "displayName": "Flight Map Canvas",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/flight-map-canvas/plugin.json",
+      "description": "Explore Google Maps using 3D flight-simulator controls while agents report their work in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/flight-map-canvas/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:flowstudio-power-automate-build",
@@ -8331,6 +8518,23 @@
         "repoPath": "skills/geofeed-tuner/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:gesture-review",
+      "displayName": "Gesture Review",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/gesture-review/plugin.json",
+      "description": "Review pull requests with a live camera feed and approve or reject them using gestures in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/gesture-review/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:gh-stack:gh-stack",
@@ -8775,6 +8979,23 @@
         "repoPath": "skills/java-mcp-server-generator/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:java-modernization-studio",
+      "displayName": "Java Modernization Studio",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/java-modernization-studio/plugin.json",
+      "description": "Drive Java modernization assessment, planning, progress, validation, and predefined tasks from a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/java-modernization-studio/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:java-refactoring-extract-method",
@@ -9665,6 +9886,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:pr-artifact-explorer",
+      "displayName": "PR Artifact Explorer",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/pr-artifact-explorer/plugin.json",
+      "description": "Navigate pull requests and securely explore GitHub Actions artifacts in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/pr-artifact-explorer/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:pr-dashboard",
       "displayName": "PR Dashboard",
       "mediaType": "application/ai-skill",
@@ -10277,6 +10515,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:release-notes-showcase",
+      "displayName": "Release Notes Showcase",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/release-notes-showcase/plugin.json",
+      "description": "Compose and refine launch-ready release notes with contributor callouts and export-friendly output in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/release-notes-showcase/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:remember-interactive-programming",
       "displayName": "Remember Interactive Programming",
       "mediaType": "application/ai-skill",
@@ -10299,6 +10554,23 @@
         "repoPath": "skills/remember/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:repo-actions-hub",
+      "displayName": "Repo Actions Hub",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/repo-actions-hub/plugin.json",
+      "description": "Browse GitHub Actions workflows, inspect recent runs, and trigger manual workflow runs from a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/repo-actions-hub/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:repo-story-time",
@@ -10577,6 +10849,40 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:signals-dashboard",
+      "displayName": "Signals Dashboard",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/signals-dashboard/plugin.json",
+      "description": "Monitor Workshop agent signals, honesty calibration, cost-aware desk profiles, and fail-closed local delegation in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/signals-dashboard/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:site-studio",
+      "displayName": "Site Studio",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/site-studio/plugin.json",
+      "description": "Plan, draft, and track a personal website with an agent in a shared GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/site-studio/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:slang-shader-engineer",
       "displayName": "Slang Shader Engineer",
       "mediaType": "application/ai-skill",
@@ -10853,6 +11159,23 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:tiny-tool-town-submitter",
+      "displayName": "Tiny Tool Town Submitter",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/tiny-tool-town-submitter/plugin.json",
+      "description": "Inspect a repository, improve its readiness, and submit a Tiny Tool Town listing from a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/tiny-tool-town-submitter/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:tldr-prompt",
       "displayName": "Tldr Prompt",
       "mediaType": "application/ai-skill",
@@ -10875,6 +11198,23 @@
         "repoPath": "skills/tm7-threat-model/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:token-pacman",
+      "displayName": "Token Pac-Man",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/token-pacman/plugin.json",
+      "description": "Visualize live session AI-credit usage as a Pac-Man board with pellets, ghosts, milestones, and limits in a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/token-pacman/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:transloadit-media-processing",
@@ -11117,6 +11457,40 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:github:awesome-copilot:where-was-i",
+      "displayName": "Where Was I",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/where-was-i/plugin.json",
+      "description": "Reconstruct branch, commit, uncommitted-work, and pull-request context in a GitHub Copilot canvas to resume development quickly.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/where-was-i/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:windows-app-storage-inspector-cleanup",
+      "displayName": "Windows App Storage Inspector Cleanup",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/windows-app-storage-inspector-cleanup/plugin.json",
+      "description": "Inspect Windows application storage, understand disk usage, and safely recycle approved cleanup items from a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/windows-app-storage-inspector-cleanup/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:github:awesome-copilot:winmd-api-search",
       "displayName": "Winmd API Search",
       "mediaType": "application/ai-skill",
@@ -11139,6 +11513,23 @@
         "repoPath": "skills/winui3-migration-guide/SKILL.md"
       },
       "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:github:awesome-copilot:work-hub",
+      "displayName": "Work Hub",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/github/awesome-copilot/blob/main/plugins/work-hub/plugin.json",
+      "description": "Manage cross-repository onboarding, focus planning, repository health, work signals, and session cleanup from a GitHub Copilot canvas.",
+      "tags": [
+        "canvas",
+        "canvas-only",
+        "github-copilot"
+      ],
+      "metadata": {
+        "sourceSet": "github/awesome-copilot",
+        "repoPath": "plugins/work-hub/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
     },
     {
       "identifier": "urn:air:github.com:github:awesome-copilot:workiq-copilot",
@@ -22007,7 +22398,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:34:48Z",
+      "updatedAt": "2026-08-25T07:49:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -22022,7 +22413,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-24T18:34:49Z",
+      "updatedAt": "2026-08-25T07:49:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22047,7 +22438,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-08-24T18:34:50Z",
+      "updatedAt": "2026-08-25T07:49:03Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22062,7 +22453,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-24T18:34:51Z",
+      "updatedAt": "2026-08-25T07:49:04Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22086,7 +22477,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-24T18:34:52Z",
+      "updatedAt": "2026-08-25T07:49:05Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -22099,7 +22490,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.nauro:nauro",
       "displayName": "Nauro",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.15.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.16.0",
       "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
       "tags": [
         "agentic-ai",
@@ -22112,8 +22503,8 @@
         "model-context-protocol",
         "claude-code"
       ],
-      "version": "1.15.0",
-      "updatedAt": "2026-08-24T18:34:53Z",
+      "version": "1.16.0",
+      "updatedAt": "2026-08-25T07:49:06Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -22137,7 +22528,7 @@
         "model-context-protocol"
       ],
       "version": "0.9.1",
-      "updatedAt": "2026-08-24T18:34:55Z",
+      "updatedAt": "2026-08-25T07:49:07Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -22165,7 +22556,7 @@
         "mcp-server"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-24T18:34:56Z",
+      "updatedAt": "2026-08-25T07:49:08Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -22218,7 +22609,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-24T18:34:57Z",
+      "updatedAt": "2026-08-25T07:49:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22244,7 +22635,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:34:58Z",
+      "updatedAt": "2026-08-25T07:49:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
@@ -22268,12 +22659,12 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:34:59Z",
+      "updatedAt": "2026-08-25T07:49:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 204,
+        "stargazerCount": 203,
         "websiteUrl": "https://glif.app/mcp"
       }
     },
@@ -22284,7 +22675,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:00Z",
+      "updatedAt": "2026-08-25T07:49:12Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -22311,7 +22702,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:35:01Z",
+      "updatedAt": "2026-08-25T07:49:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -22333,7 +22724,7 @@
         "readmeUrl": "https://github.com/azure-ai-foundry/mcp-foundry#readme",
         "repository": "https://github.com/azure-ai-foundry/mcp-foundry",
         "repositorySource": "github",
-        "stargazerCount": 254
+        "stargazerCount": 255
       }
     },
     {
@@ -22407,7 +22798,7 @@
         "mcp"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-24T18:35:03Z",
+      "updatedAt": "2026-08-25T07:49:15Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22424,7 +22815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:04Z",
+      "updatedAt": "2026-08-25T07:49:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22452,7 +22843,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-24T18:35:05Z",
+      "updatedAt": "2026-08-25T07:49:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -22515,13 +22906,13 @@
         "mcp-server"
       ],
       "version": "0.15.1",
-      "updatedAt": "2026-08-24T18:35:06Z",
+      "updatedAt": "2026-08-25T07:49:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4798
+        "stargazerCount": 4839
       }
     },
     {
@@ -22543,13 +22934,13 @@
         "cursor"
       ],
       "version": "1.1.3",
-      "updatedAt": "2026-08-24T18:35:08Z",
+      "updatedAt": "2026-08-25T07:49:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
         "repository": "https://github.com/atlassian/atlassian-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 982,
+        "stargazerCount": 983,
         "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/"
       }
     },
@@ -22560,7 +22951,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-24T18:35:09Z",
+      "updatedAt": "2026-08-25T07:49:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -22575,7 +22966,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:10Z",
+      "updatedAt": "2026-08-25T07:49:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22591,7 +22982,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:11Z",
+      "updatedAt": "2026-08-25T07:49:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22607,7 +22998,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:12Z",
+      "updatedAt": "2026-08-25T07:49:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22623,7 +23014,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:13Z",
+      "updatedAt": "2026-08-25T07:49:25Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22639,7 +23030,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:14Z",
+      "updatedAt": "2026-08-25T07:49:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22655,7 +23046,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:15Z",
+      "updatedAt": "2026-08-25T07:49:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22671,7 +23062,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:16Z",
+      "updatedAt": "2026-08-25T07:49:27Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22687,7 +23078,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-24T18:35:17Z",
+      "updatedAt": "2026-08-25T07:49:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -22701,7 +23092,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-24T18:35:18Z",
+      "updatedAt": "2026-08-25T07:49:30Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -22727,7 +23118,7 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-08-24T18:35:19Z",
+      "updatedAt": "2026-08-25T07:49:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
@@ -22755,7 +23146,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:35:21Z",
+      "updatedAt": "2026-08-25T07:49:32Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -22772,7 +23163,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-08-24T18:35:22Z",
+      "updatedAt": "2026-08-25T07:49:33Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -22786,7 +23177,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:35:23Z",
+      "updatedAt": "2026-08-25T07:49:34Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
@@ -22813,7 +23204,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-24T18:35:24Z",
+      "updatedAt": "2026-08-25T07:49:35Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -22829,7 +23220,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:25Z",
+      "updatedAt": "2026-08-25T07:49:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -22844,7 +23235,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:26Z",
+      "updatedAt": "2026-08-25T07:49:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -22869,7 +23260,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:27Z",
+      "updatedAt": "2026-08-25T07:49:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -22895,7 +23286,7 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-24T18:35:28Z",
+      "updatedAt": "2026-08-25T07:49:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
@@ -22911,7 +23302,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-24T18:35:29Z",
+      "updatedAt": "2026-08-25T07:49:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -22938,7 +23329,7 @@
         "technical-drawing"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:35:31Z",
+      "updatedAt": "2026-08-25T07:49:41Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -22962,7 +23353,7 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-08-24T18:35:32Z",
+      "updatedAt": "2026-08-25T07:49:42Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -22982,7 +23373,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:35:33Z",
+      "updatedAt": "2026-08-25T07:49:44Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23009,7 +23400,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:34Z",
+      "updatedAt": "2026-08-25T07:49:45Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -23035,7 +23426,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:35:36Z",
+      "updatedAt": "2026-08-25T07:49:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
@@ -23061,7 +23452,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-24T18:35:37Z",
+      "updatedAt": "2026-08-25T07:49:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23077,14 +23468,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.37",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
       "version": "3.0.0-beta.37",
-      "updatedAt": "2026-08-24T18:35:38Z",
+      "updatedAt": "2026-08-25T07:49:48Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Azure.Mcp.Server",
-        "stargazerCount": 3599,
+        "stargazerCount": 3600,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server"
       }
     },
@@ -23095,14 +23486,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.3.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
       "version": "1.3.0",
-      "updatedAt": "2026-08-24T18:35:39Z",
+      "updatedAt": "2026-08-25T07:49:50Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Fabric.Mcp.Server",
-        "stargazerCount": 3599,
+        "stargazerCount": 3600,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
       }
     },
@@ -23113,7 +23504,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-08-24T18:35:41Z",
+      "updatedAt": "2026-08-25T07:49:51Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
@@ -23130,7 +23521,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:42Z",
+      "updatedAt": "2026-08-25T07:49:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23149,7 +23540,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:43Z",
+      "updatedAt": "2026-08-25T07:49:53Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -23171,7 +23562,7 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-08-24T18:35:44Z",
+      "updatedAt": "2026-08-25T07:49:54Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
@@ -23194,7 +23585,7 @@
         "sports-betting"
       ],
       "version": "1.4.3",
-      "updatedAt": "2026-08-24T18:35:45Z",
+      "updatedAt": "2026-08-25T07:49:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
         "repository": "https://github.com/negative-ev/negativeev-mcp",
@@ -23209,7 +23600,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:46Z",
+      "updatedAt": "2026-08-25T07:49:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23236,13 +23627,13 @@
         "copilot"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-24T18:35:47Z",
+      "updatedAt": "2026-08-25T07:49:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
         "repository": "https://github.com/postmanlabs/postman-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 305
+        "stargazerCount": 307
       }
     },
     {
@@ -23252,7 +23643,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-24T18:35:49Z",
+      "updatedAt": "2026-08-25T07:49:58Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23281,7 +23672,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:50Z",
+      "updatedAt": "2026-08-25T07:50:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23306,7 +23697,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:51Z",
+      "updatedAt": "2026-08-25T07:50:01Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23332,7 +23723,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:52Z",
+      "updatedAt": "2026-08-25T07:50:02Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23348,7 +23739,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.47.27",
-      "updatedAt": "2026-08-24T18:35:53Z",
+      "updatedAt": "2026-08-25T07:50:03Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23375,7 +23766,7 @@
         "static-site"
       ],
       "version": "1.3.5",
-      "updatedAt": "2026-08-24T18:35:54Z",
+      "updatedAt": "2026-08-25T07:50:04Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
@@ -23404,7 +23795,7 @@
         "swagger"
       ],
       "version": "0.37.0",
-      "updatedAt": "2026-08-24T18:35:56Z",
+      "updatedAt": "2026-08-25T07:50:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -23432,7 +23823,7 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-08-24T18:35:58Z",
+      "updatedAt": "2026-08-25T07:50:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -23448,7 +23839,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:59Z",
+      "updatedAt": "2026-08-25T07:50:08Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -23466,7 +23857,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-24T18:36:00Z",
+      "updatedAt": "2026-08-25T07:50:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -23483,7 +23874,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-24T18:36:01Z",
+      "updatedAt": "2026-08-25T07:50:10Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
@@ -23499,7 +23890,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-08-24T18:36:02Z",
+      "updatedAt": "2026-08-25T07:50:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
@@ -23524,13 +23915,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-08-24T18:36:03Z",
+      "updatedAt": "2026-08-25T07:50:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
         "repository": "https://github.com/stripe/agent-toolkit",
         "repositorySource": "github",
-        "stargazerCount": 1762
+        "stargazerCount": 1763
       }
     },
     {
@@ -23540,7 +23931,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.11.0",
       "description": "MCP server for interacting with the Supabase platform",
       "version": "0.11.0",
-      "updatedAt": "2026-08-24T18:36:04Z",
+      "updatedAt": "2026-08-25T07:50:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
@@ -23558,7 +23949,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.1.2",
-      "updatedAt": "2026-08-24T18:36:06Z",
+      "updatedAt": "2026-08-25T07:50:15Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -23574,7 +23965,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-08-24T18:36:07Z",
+      "updatedAt": "2026-08-25T07:50:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
@@ -23596,13 +23987,13 @@
         "business-critical-yes"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:36:08Z",
+      "updatedAt": "2026-08-25T07:50:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/webflow/mcp-server#readme",
         "repository": "https://github.com/webflow/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 138
+        "stargazerCount": 137
       }
     },
     {
@@ -23612,7 +24003,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.wix%2Fmcp/versions/1.0.2",
       "description": "A Model Context Protocol server for Wix AI tools",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:36:09Z",
+      "updatedAt": "2026-08-25T07:50:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/wix/wix-mcp#readme",
         "repository": "https://github.com/wix/wix-mcp",
@@ -23639,7 +24030,7 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:36:10Z",
+      "updatedAt": "2026-08-25T07:50:19Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
@@ -23665,7 +24056,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:36:11Z",
+      "updatedAt": "2026-08-25T07:50:20Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -23693,7 +24084,7 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-24T18:36:12Z",
+      "updatedAt": "2026-08-25T07:50:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
@@ -23728,7 +24119,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 13622
+        "stargazerCount": 13634
       }
     },
     {
@@ -23748,7 +24139,7 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:36:13Z",
+      "updatedAt": "2026-08-25T07:50:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
@@ -23774,7 +24165,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-08-24T18:36:15Z",
+      "updatedAt": "2026-08-25T07:50:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -23790,7 +24181,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.svelte%2Fmcp/versions/0.1.26",
       "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
       "version": "0.1.26",
-      "updatedAt": "2026-08-24T18:36:16Z",
+      "updatedAt": "2026-08-25T07:50:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/sveltejs/ai-tools/tree/HEAD/packages/mcp-stdio",
@@ -23808,7 +24199,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:36:17Z",
+      "updatedAt": "2026-08-25T07:50:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -23862,7 +24253,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-24T18:36:18Z",
+      "updatedAt": "2026-08-25T07:50:27Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -23896,7 +24287,7 @@
         "readmeUrl": "https://github.com/firecrawl/firecrawl-mcp-server#readme",
         "repository": "https://github.com/firecrawl/firecrawl-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 7308
+        "stargazerCount": 7310
       }
     },
     {
@@ -23912,7 +24303,7 @@
         "voice-agents"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-24T18:36:19Z",
+      "updatedAt": "2026-08-25T07:50:28Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/saaslabsco/justcall-mcp-server#readme",
@@ -23972,7 +24363,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-24T18:36:20Z",
+      "updatedAt": "2026-08-25T07:50:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24000,7 +24391,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:36:22Z",
+      "updatedAt": "2026-08-25T07:50:30Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24029,7 +24420,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:36:23Z",
+      "updatedAt": "2026-08-25T07:50:31Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24058,7 +24449,7 @@
         "ai-native"
       ],
       "version": "1.16.3",
-      "updatedAt": "2026-08-24T18:36:24Z",
+      "updatedAt": "2026-08-25T07:50:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24086,7 +24477,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-24T18:36:25Z",
+      "updatedAt": "2026-08-25T07:50:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24103,7 +24494,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AnimaApp%2Fanima/versions/1.0.0",
       "description": "Connect AI coding agents to Anima Playground, Figma, and your design system.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:26Z",
+      "updatedAt": "2026-08-25T07:50:35Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/AnimaApp/mcp-server-guide#readme",
@@ -24119,7 +24510,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-24T18:36:27Z",
+      "updatedAt": "2026-08-25T07:50:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24144,13 +24535,13 @@
         "mcp"
       ],
       "version": "1.7.0",
-      "updatedAt": "2026-08-24T18:36:28Z",
+      "updatedAt": "2026-08-25T07:50:38Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ChromeDevTools/chrome-devtools-mcp#readme",
         "repository": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 49652
+        "stargazerCount": 49671
       }
     },
     {
@@ -24160,7 +24551,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.4.1",
-      "updatedAt": "2026-08-24T18:36:30Z",
+      "updatedAt": "2026-08-25T07:50:39Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
@@ -24177,7 +24568,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-24T18:36:31Z",
+      "updatedAt": "2026-08-25T07:50:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
@@ -24200,7 +24591,7 @@
         "mcp-server"
       ],
       "version": "0.17.0",
-      "updatedAt": "2026-08-24T18:36:32Z",
+      "updatedAt": "2026-08-25T07:50:41Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/CrowdStrike/falcon-mcp#readme",
@@ -24228,7 +24619,7 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-24T18:36:34Z",
+      "updatedAt": "2026-08-25T07:50:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
@@ -24254,7 +24645,7 @@
         "scaffolding"
       ],
       "version": "15.5.1",
-      "updatedAt": "2026-08-24T18:36:36Z",
+      "updatedAt": "2026-08-25T07:50:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24282,7 +24673,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-24T18:36:37Z",
+      "updatedAt": "2026-08-25T07:50:47Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24298,7 +24689,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-08-24T18:36:38Z",
+      "updatedAt": "2026-08-25T07:50:48Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
@@ -24327,7 +24718,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:40Z",
+      "updatedAt": "2026-08-25T07:50:50Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -24355,7 +24746,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-24T18:36:41Z",
+      "updatedAt": "2026-08-25T07:50:51Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24374,7 +24765,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:42Z",
+      "updatedAt": "2026-08-25T07:50:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24389,7 +24780,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
       "version": "0.8.0",
-      "updatedAt": "2026-08-24T18:36:43Z",
+      "updatedAt": "2026-08-25T07:50:53Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
@@ -24406,7 +24797,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.PagerDuty%2Fpagerduty-mcp/versions/0.2.1",
       "description": "PagerDuty's official MCP server which provides tools to interact with your PagerDuty account.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-24T18:36:44Z",
+      "updatedAt": "2026-08-25T07:50:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/PagerDuty/pagerduty-mcp-server#readme",
@@ -24434,7 +24825,7 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.11",
-      "updatedAt": "2026-08-24T18:36:45Z",
+      "updatedAt": "2026-08-25T07:50:55Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
@@ -24451,7 +24842,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-24T18:36:46Z",
+      "updatedAt": "2026-08-25T07:50:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24473,7 +24864,7 @@
         "ui5"
       ],
       "version": "1.11.13",
-      "updatedAt": "2026-08-24T18:36:48Z",
+      "updatedAt": "2026-08-25T07:50:58Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SAP/open-ux-tools/tree/HEAD/packages/fiori-mcp-server",
@@ -24495,7 +24886,7 @@
         "webcrawler"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:36:49Z",
+      "updatedAt": "2026-08-25T07:50:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ScrapeGraphAI/scrapegraph-mcp#readme",
@@ -24523,7 +24914,7 @@
         "mcp-tools"
       ],
       "version": "1.6.1",
-      "updatedAt": "2026-08-24T18:36:50Z",
+      "updatedAt": "2026-08-25T07:51:00Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
@@ -24551,13 +24942,13 @@
         "static-analysis"
       ],
       "version": "1.21.0",
-      "updatedAt": "2026-08-24T18:36:51Z",
+      "updatedAt": "2026-08-25T07:51:01Z",
       "metadata": {
         "primaryLanguage": "Java",
         "readmeUrl": "https://github.com/SonarSource/sonarqube-mcp-server#readme",
         "repository": "https://github.com/SonarSource/sonarqube-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 631
+        "stargazerCount": 632
       }
     },
     {
@@ -24574,7 +24965,7 @@
         "mcp-server"
       ],
       "version": "0.2.18",
-      "updatedAt": "2026-08-24T18:36:53Z",
+      "updatedAt": "2026-08-25T07:51:02Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/mcp-server#readme",
@@ -24598,7 +24989,7 @@
         "webcomponent"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-24T18:36:54Z",
+      "updatedAt": "2026-08-25T07:51:04Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/webcomponents-mcp-server#readme",
@@ -24625,7 +25016,7 @@
         "mcp"
       ],
       "version": "2.2.0",
-      "updatedAt": "2026-08-24T18:36:56Z",
+      "updatedAt": "2026-08-25T07:51:05Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -24642,7 +25033,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.0",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
       "version": "1.30.0",
-      "updatedAt": "2026-08-24T18:36:57Z",
+      "updatedAt": "2026-08-25T07:51:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -24665,7 +25056,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-24T18:36:58Z",
+      "updatedAt": "2026-08-25T07:51:07Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -24693,7 +25084,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-24T18:37:00Z",
+      "updatedAt": "2026-08-25T07:51:08Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -24721,7 +25112,7 @@
         "ai-agents"
       ],
       "version": "0.18.0",
-      "updatedAt": "2026-08-24T18:37:01Z",
+      "updatedAt": "2026-08-25T07:51:09Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -24750,7 +25141,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-08-24T18:37:02Z",
+      "updatedAt": "2026-08-25T07:51:11Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -24767,7 +25158,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-08-24T18:37:03Z",
+      "updatedAt": "2026-08-25T07:51:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -24796,13 +25187,13 @@
         "knowlege-graph"
       ],
       "version": "0.23.0",
-      "updatedAt": "2026-08-24T18:37:04Z",
+      "updatedAt": "2026-08-25T07:51:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
         "repository": "https://github.com/basicmachines-co/basic-memory.git",
         "repositorySource": "github",
-        "stargazerCount": 3743
+        "stargazerCount": 3752
       }
     },
     {
@@ -24824,7 +25215,7 @@
         "data-extraction"
       ],
       "version": "2.11.1",
-      "updatedAt": "2026-08-24T18:37:06Z",
+      "updatedAt": "2026-08-25T07:51:14Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
@@ -24852,7 +25243,7 @@
         "sqlserver"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-24T18:37:07Z",
+      "updatedAt": "2026-08-25T07:51:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
@@ -24880,7 +25271,7 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:08Z",
+      "updatedAt": "2026-08-25T07:51:17Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
@@ -24908,7 +25299,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:37:09Z",
+      "updatedAt": "2026-08-25T07:51:18Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -24937,7 +25328,7 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-24T18:37:11Z",
+      "updatedAt": "2026-08-25T07:51:19Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
@@ -24963,7 +25354,7 @@
         "gemini-cli-extension"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-08-24T18:37:12Z",
+      "updatedAt": "2026-08-25T07:51:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
@@ -24980,7 +25371,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-24T18:37:13Z",
+      "updatedAt": "2026-08-25T07:51:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25008,7 +25399,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.3",
-      "updatedAt": "2026-08-24T18:37:14Z",
+      "updatedAt": "2026-08-25T07:51:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -25033,7 +25424,7 @@
         "copilot"
       ],
       "version": "2.1.2",
-      "updatedAt": "2026-08-24T18:37:15Z",
+      "updatedAt": "2026-08-25T07:51:23Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/Dynatrace-mcp#readme",
@@ -25049,7 +25440,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2Fdynatrace-managed-mcp/versions/1.0.1",
       "description": "MCP server for Dynatrace Managed to access logs, events, and metrics.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:37:17Z",
+      "updatedAt": "2026-08-25T07:51:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -25065,7 +25456,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-08-24T18:37:18Z",
+      "updatedAt": "2026-08-25T07:51:26Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
@@ -25081,7 +25472,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-08-24T18:37:19Z",
+      "updatedAt": "2026-08-25T07:51:27Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -25101,14 +25492,14 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-08-24T18:37:20Z",
+      "updatedAt": "2026-08-25T07:51:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/getsentry/sentry-mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 827
+        "stargazerCount": 828
       }
     },
     {
@@ -25123,13 +25514,13 @@
         "mcp-server"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-24T18:37:21Z",
+      "updatedAt": "2026-08-25T07:51:29Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32466
+        "stargazerCount": 32486
       }
     },
     {
@@ -25144,7 +25535,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:37:23Z",
+      "updatedAt": "2026-08-25T07:51:31Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -25160,13 +25551,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:25Z",
+      "updatedAt": "2026-08-25T07:51:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
         "repository": "https://github.com/hashicorp/terraform-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1511
+        "stargazerCount": 1512
       }
     },
     {
@@ -25188,7 +25579,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:37:26Z",
+      "updatedAt": "2026-08-25T07:51:33Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -25201,7 +25592,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.hostinger:hostinger-api-mcp",
       "displayName": "Hostinger API",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.46.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.47.0",
       "description": "MCP server for Hostinger API",
       "tags": [
         "ai",
@@ -25212,14 +25603,14 @@
         "mcp",
         "gemini-cli-extension"
       ],
-      "version": "1.46.0",
-      "updatedAt": "2026-08-24T18:37:27Z",
+      "version": "1.47.0",
+      "updatedAt": "2026-08-25T07:51:34Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
         "repository": "https://github.com/hostinger/api-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 143
+        "stargazerCount": 142
       }
     },
     {
@@ -25241,7 +25632,7 @@
         "privacy"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:37:29Z",
+      "updatedAt": "2026-08-25T07:51:36Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
@@ -25269,7 +25660,7 @@
         "rag"
       ],
       "version": "4.13.3",
-      "updatedAt": "2026-08-24T18:37:31Z",
+      "updatedAt": "2026-08-25T07:51:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
@@ -25296,7 +25687,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:37:33Z",
+      "updatedAt": "2026-08-25T07:51:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -25308,10 +25699,10 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.likhithreddy:fittok",
       "displayName": "fittok",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.1",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
-      "version": "0.11.0",
-      "updatedAt": "2026-08-24T18:37:34Z",
+      "version": "0.11.1",
+      "updatedAt": "2026-08-25T07:51:40Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25327,7 +25718,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-08-24T18:37:35Z",
+      "updatedAt": "2026-08-25T07:51:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
@@ -25343,7 +25734,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-08-24T18:37:36Z",
+      "updatedAt": "2026-08-25T07:51:42Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
@@ -25359,19 +25750,19 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:37Z",
+      "updatedAt": "2026-08-25T07:51:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
         "repositorySource": "github",
-        "stargazerCount": 48
+        "stargazerCount": 49
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.microsoft:awesome-copilot",
       "displayName": "Awesome Copilot MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026082402",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026082505",
       "description": "An MCP server that stores Copilot customizations from the Awesome Copilot repository",
       "tags": [
         "dotnet",
@@ -25379,8 +25770,8 @@
         "mcp-client",
         "mcp-server"
       ],
-      "version": "1.0.2026082402",
-      "updatedAt": "2026-08-24T18:37:39Z",
+      "version": "1.0.2026082505",
+      "updatedAt": "2026-08-25T07:51:45Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -25397,7 +25788,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:37:41Z",
+      "updatedAt": "2026-08-25T07:51:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
@@ -25425,7 +25816,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.5",
-      "updatedAt": "2026-08-24T18:37:43Z",
+      "updatedAt": "2026-08-25T07:51:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25454,7 +25845,7 @@
         "mcp"
       ],
       "version": "0.8.8",
-      "updatedAt": "2026-08-24T18:37:44Z",
+      "updatedAt": "2026-08-25T07:51:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -25478,7 +25869,7 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-08-24T18:37:45Z",
+      "updatedAt": "2026-08-25T07:51:50Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
@@ -25506,14 +25897,14 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-08-24T18:37:46Z",
+      "updatedAt": "2026-08-25T07:51:51Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
         "repository": "https://github.com/netdata/netdata",
         "repositorySource": "github",
         "repositorySubfolder": "docs/netdata-ai/mcp",
-        "stargazerCount": 80277,
+        "stargazerCount": 80285,
         "websiteUrl": "https://www.netdata.cloud"
       }
     },
@@ -25524,7 +25915,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:48Z",
+      "updatedAt": "2026-08-25T07:51:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -25552,13 +25943,13 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:37:49Z",
+      "updatedAt": "2026-08-25T07:51:53Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
         "repository": "https://github.com/oleksiijko/pmb",
         "repositorySource": "github",
-        "stargazerCount": 296
+        "stargazerCount": 297
       }
     },
     {
@@ -25580,13 +25971,13 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:50Z",
+      "updatedAt": "2026-08-25T07:51:55Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
         "repository": "https://github.com/openaccountants/openaccountants",
         "repositorySource": "github",
-        "stargazerCount": 341
+        "stargazerCount": 342
       }
     },
     {
@@ -25596,7 +25987,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
       "version": "0.2.0",
-      "updatedAt": "2026-08-24T18:37:51Z",
+      "updatedAt": "2026-08-25T07:51:56Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -25613,7 +26004,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-08-24T18:37:52Z",
+      "updatedAt": "2026-08-25T07:51:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -25629,7 +26020,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.46.4",
-      "updatedAt": "2026-08-24T18:37:53Z",
+      "updatedAt": "2026-08-25T07:51:58Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
@@ -25658,7 +26049,7 @@
         "ucg-fiber"
       ],
       "version": "0.21.1",
-      "updatedAt": "2026-08-24T18:37:54Z",
+      "updatedAt": "2026-08-25T07:51:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
@@ -25683,7 +26074,7 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:56Z",
+      "updatedAt": "2026-08-25T07:52:00Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
@@ -25711,7 +26102,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:37:57Z",
+      "updatedAt": "2026-08-25T07:52:01Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -25735,7 +26126,7 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-08-24T18:37:58Z",
+      "updatedAt": "2026-08-25T07:52:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
@@ -25752,7 +26143,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:37:59Z",
+      "updatedAt": "2026-08-25T07:52:04Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -25780,7 +26171,7 @@
         "mcp"
       ],
       "version": "6.0.0",
-      "updatedAt": "2026-08-24T18:38:00Z",
+      "updatedAt": "2026-08-25T07:52:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
@@ -25796,7 +26187,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:38:02Z",
+      "updatedAt": "2026-08-25T07:52:06Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -25816,13 +26207,13 @@
         "sas-osp"
       ],
       "version": "1.11.1",
-      "updatedAt": "2026-08-24T18:38:03Z",
+      "updatedAt": "2026-08-25T07:52:07Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
         "repository": "https://github.com/sassoftware/sas-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 51
+        "stargazerCount": 52
       }
     },
     {
@@ -25844,7 +26235,7 @@
         "x402"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:38:05Z",
+      "updatedAt": "2026-08-25T07:52:09Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
@@ -25861,7 +26252,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.1",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:06Z",
+      "updatedAt": "2026-08-25T07:52:10Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
@@ -25889,7 +26280,7 @@
         "semantic-scholar"
       ],
       "version": "1.7.3",
-      "updatedAt": "2026-08-24T18:38:07Z",
+      "updatedAt": "2026-08-25T07:52:11Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
@@ -25905,7 +26296,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:38:08Z",
+      "updatedAt": "2026-08-25T07:52:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -25922,7 +26313,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-24T18:38:09Z",
+      "updatedAt": "2026-08-25T07:52:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -25938,7 +26329,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:38:10Z",
+      "updatedAt": "2026-08-25T07:52:14Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -25965,7 +26356,7 @@
         "stackql"
       ],
       "version": "0.10.605",
-      "updatedAt": "2026-08-24T18:38:11Z",
+      "updatedAt": "2026-08-25T07:52:15Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
@@ -25990,7 +26381,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:12Z",
+      "updatedAt": "2026-08-25T07:52:16Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -26007,13 +26398,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-08-24T18:38:13Z",
+      "updatedAt": "2026-08-25T07:52:17Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
         "repository": "https://github.com/tavily-ai/tavily-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2350
+        "stargazerCount": 2352
       }
     },
     {
@@ -26035,7 +26426,7 @@
         "anti-ui-slop"
       ],
       "version": "3.0.0",
-      "updatedAt": "2026-08-24T18:38:14Z",
+      "updatedAt": "2026-08-25T07:52:18Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
@@ -26058,13 +26449,13 @@
         "vibe-coding"
       ],
       "version": "1.0.31",
-      "updatedAt": "2026-08-24T18:38:16Z",
+      "updatedAt": "2026-08-25T07:52:19Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
         "repository": "https://github.com/upstash/context7",
         "repositorySource": "github",
-        "stargazerCount": 61155
+        "stargazerCount": 61180
       }
     },
     {
@@ -26074,7 +26465,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-08-24T18:38:17Z",
+      "updatedAt": "2026-08-25T07:52:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -26097,7 +26488,7 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-08-24T18:38:18Z",
+      "updatedAt": "2026-08-25T07:52:22Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
@@ -26125,7 +26516,7 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-24T18:38:19Z",
+      "updatedAt": "2026-08-25T07:52:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
@@ -26152,13 +26543,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.47",
-      "updatedAt": "2026-08-24T18:38:20Z",
+      "updatedAt": "2026-08-25T07:52:24Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
         "repository": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
         "repositorySource": "github",
-        "stargazerCount": 9388
+        "stargazerCount": 9389
       }
     },
     {
@@ -26171,7 +26562,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-24T18:38:22Z",
+      "updatedAt": "2026-08-25T07:52:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -26187,13 +26578,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.52",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
       "version": "2.1.52",
-      "updatedAt": "2026-08-24T18:38:23Z",
+      "updatedAt": "2026-08-25T07:52:26Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
         "repository": "https://github.com/zereight/gitlab-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1917
+        "stargazerCount": 1920
       }
     },
     {
@@ -26215,7 +26606,7 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-08-24T18:38:25Z",
+      "updatedAt": "2026-08-25T07:52:28Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
@@ -26232,7 +26623,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
       "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:38:26Z",
+      "updatedAt": "2026-08-25T07:52:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -26260,7 +26651,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-24T18:38:27Z",
+      "updatedAt": "2026-08-25T07:52:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -26276,7 +26667,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:38:28Z",
+      "updatedAt": "2026-08-25T07:52:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -26291,7 +26682,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:38:29Z",
+      "updatedAt": "2026-08-25T07:52:32Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -26312,7 +26703,7 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-08-24T18:38:31Z",
+      "updatedAt": "2026-08-25T07:52:33Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
@@ -26328,7 +26719,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-24T18:38:32Z",
+      "updatedAt": "2026-08-25T07:52:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -26373,7 +26764,7 @@
         "readmeUrl": "https://github.com/makenotion/notion-mcp-server#readme",
         "repository": "https://github.com/makenotion/notion-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4601
+        "stargazerCount": 4603
       }
     },
     {
@@ -26389,7 +26780,7 @@
         "readmeUrl": "https://github.com/microsoft/azure-devops-mcp#readme",
         "repository": "https://github.com/microsoft/azure-devops-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1977
+        "stargazerCount": 1978
       }
     },
     {
@@ -26465,7 +26856,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 175983
+        "stargazerCount": 176100
       }
     },
     {
@@ -26485,7 +26876,7 @@
         "readmeUrl": "https://github.com/microsoft/playwright-mcp#readme",
         "repository": "https://github.com/microsoft/playwright-mcp",
         "repositorySource": "github",
-        "stargazerCount": 36424
+        "stargazerCount": 36442
       }
     },
     {
@@ -26513,7 +26904,7 @@
         "readmeUrl": "https://github.com/microsoftdocs/mcp#readme",
         "repository": "https://github.com/microsoftdocs/mcp",
         "repositorySource": "github",
-        "stargazerCount": 1856
+        "stargazerCount": 1858
       }
     },
     {
@@ -26572,7 +26963,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-08-24T18:38:33Z",
+      "updatedAt": "2026-08-25T07:52:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -26601,7 +26992,7 @@
         "typescript"
       ],
       "version": "2.3.1",
-      "updatedAt": "2026-08-24T18:38:34Z",
+      "updatedAt": "2026-08-25T07:52:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -26636,7 +27027,7 @@
         "readmeUrl": "https://github.com/oraios/serena#readme",
         "repository": "https://github.com/oraios/serena",
         "repositorySource": "github",
-        "stargazerCount": 28445
+        "stargazerCount": 28470
       }
     },
     {
@@ -26658,7 +27049,7 @@
         "rust"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-08-24T18:38:35Z",
+      "updatedAt": "2026-08-25T07:52:38Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -26687,7 +27078,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:37Z",
+      "updatedAt": "2026-08-25T07:52:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -26746,7 +27137,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:38Z",
+      "updatedAt": "2026-08-25T07:52:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",
@@ -26779,7 +27170,7 @@
         "readmeUrl": "https://github.com/zapier/zapier-mcp#readme",
         "repository": "https://github.com/zapier/zapier-mcp",
         "repositorySource": "github",
-        "stargazerCount": 389
+        "stargazerCount": 388
       }
     }
   ]

--- a/catalog/github/accessibility-kanban.json
+++ b/catalog/github/accessibility-kanban.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:accessibility-kanban",
+  "displayName": "Accessibility Kanban",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/accessibility-kanban/plugin.json",
+  "description": "Kanban board to manage accessibility issues and plan, track, and complete remediation work.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/accessibility-kanban/plugin.json"
+  }
+}

--- a/catalog/github/apng-studio.json
+++ b/catalog/github/apng-studio.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:apng-studio",
+  "displayName": "APNG Studio",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/apng-studio/plugin.json",
+  "description": "Build Animated PNG files in an interactive GitHub Copilot canvas by drawing or uploading frames, tuning animation settings, previewing, and exporting.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/apng-studio/plugin.json"
+  }
+}

--- a/catalog/github/arcade-canvas.json
+++ b/catalog/github/arcade-canvas.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:arcade-canvas",
+  "displayName": "Arcade Canvas",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/arcade-canvas/plugin.json",
+  "description": "Play five retro Phaser mini-games in a GitHub Copilot canvas while agents work.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/arcade-canvas/plugin.json"
+  }
+}

--- a/catalog/github/backlog-swipe-triage.json
+++ b/catalog/github/backlog-swipe-triage.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:backlog-swipe-triage",
+  "displayName": "Backlog Swipe Triage",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/backlog-swipe-triage/plugin.json",
+  "description": "Swipe through backlog issues in a GitHub Copilot canvas to assign, request information, defer, close, or ignore them.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/backlog-swipe-triage/plugin.json"
+  }
+}

--- a/catalog/github/backrooms-canvas.json
+++ b/catalog/github/backrooms-canvas.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:backrooms-canvas",
+  "displayName": "Backrooms Canvas",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/backrooms-canvas/plugin.json",
+  "description": "Wander an endless first-person backrooms in a GitHub Copilot canvas while agent status is ghost-written on the walls.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/backrooms-canvas/plugin.json"
+  }
+}

--- a/catalog/github/chat-cards.json
+++ b/catalog/github/chat-cards.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:chat-cards",
+  "displayName": "Chat Cards",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/chat-cards/plugin.json",
+  "description": "Present interactive cards, tables, charts, forms, documents, and videos in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/chat-cards/plugin.json"
+  }
+}

--- a/catalog/github/chromium-control-canvas.json
+++ b/catalog/github/chromium-control-canvas.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:chromium-control-canvas",
+  "displayName": "Chromium Control Canvas",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/chromium-control-canvas/plugin.json",
+  "description": "Navigate and interact with a real Chromium window through a GitHub Copilot canvas control panel and agent actions.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/chromium-control-canvas/plugin.json"
+  }
+}

--- a/catalog/github/color-orb.json
+++ b/catalog/github/color-orb.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:color-orb",
+  "displayName": "Color Orb",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/color-orb/plugin.json",
+  "description": "Interact with an agent-controlled color orb and live activity log in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/color-orb/plugin.json"
+  }
+}

--- a/catalog/github/diagram-viewer.json
+++ b/catalog/github/diagram-viewer.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:diagram-viewer",
+  "displayName": "Diagram Viewer",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/diagram-viewer/plugin.json",
+  "description": "Render interactive diagrams, drill into nodes, and view agent-generated explanations in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/diagram-viewer/plugin.json"
+  }
+}

--- a/catalog/github/feedback-themes.json
+++ b/catalog/github/feedback-themes.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:feedback-themes",
+  "displayName": "Feedback Themes",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/feedback-themes/plugin.json",
+  "description": "Explore grouped customer feedback signals by impact and drill into themes in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/feedback-themes/plugin.json"
+  }
+}

--- a/catalog/github/flight-map-canvas.json
+++ b/catalog/github/flight-map-canvas.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:flight-map-canvas",
+  "displayName": "Flight Map Canvas",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/flight-map-canvas/plugin.json",
+  "description": "Explore Google Maps using 3D flight-simulator controls while agents report their work in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/flight-map-canvas/plugin.json"
+  }
+}

--- a/catalog/github/gesture-review.json
+++ b/catalog/github/gesture-review.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:gesture-review",
+  "displayName": "Gesture Review",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/gesture-review/plugin.json",
+  "description": "Review pull requests with a live camera feed and approve or reject them using gestures in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/gesture-review/plugin.json"
+  }
+}

--- a/catalog/github/java-modernization-studio.json
+++ b/catalog/github/java-modernization-studio.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:java-modernization-studio",
+  "displayName": "Java Modernization Studio",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/java-modernization-studio/plugin.json",
+  "description": "Drive Java modernization assessment, planning, progress, validation, and predefined tasks from a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/java-modernization-studio/plugin.json"
+  }
+}

--- a/catalog/github/pr-artifact-explorer.json
+++ b/catalog/github/pr-artifact-explorer.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:pr-artifact-explorer",
+  "displayName": "PR Artifact Explorer",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/pr-artifact-explorer/plugin.json",
+  "description": "Navigate pull requests and securely explore GitHub Actions artifacts in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/pr-artifact-explorer/plugin.json"
+  }
+}

--- a/catalog/github/release-notes-showcase.json
+++ b/catalog/github/release-notes-showcase.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:release-notes-showcase",
+  "displayName": "Release Notes Showcase",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/release-notes-showcase/plugin.json",
+  "description": "Compose and refine launch-ready release notes with contributor callouts and export-friendly output in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/release-notes-showcase/plugin.json"
+  }
+}

--- a/catalog/github/repo-actions-hub.json
+++ b/catalog/github/repo-actions-hub.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:repo-actions-hub",
+  "displayName": "Repo Actions Hub",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/repo-actions-hub/plugin.json",
+  "description": "Browse GitHub Actions workflows, inspect recent runs, and trigger manual workflow runs from a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/repo-actions-hub/plugin.json"
+  }
+}

--- a/catalog/github/signals-dashboard.json
+++ b/catalog/github/signals-dashboard.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:signals-dashboard",
+  "displayName": "Signals Dashboard",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/signals-dashboard/plugin.json",
+  "description": "Monitor Workshop agent signals, honesty calibration, cost-aware desk profiles, and fail-closed local delegation in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/signals-dashboard/plugin.json"
+  }
+}

--- a/catalog/github/site-studio.json
+++ b/catalog/github/site-studio.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:site-studio",
+  "displayName": "Site Studio",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/site-studio/plugin.json",
+  "description": "Plan, draft, and track a personal website with an agent in a shared GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/site-studio/plugin.json"
+  }
+}

--- a/catalog/github/tiny-tool-town-submitter.json
+++ b/catalog/github/tiny-tool-town-submitter.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:tiny-tool-town-submitter",
+  "displayName": "Tiny Tool Town Submitter",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/tiny-tool-town-submitter/plugin.json",
+  "description": "Inspect a repository, improve its readiness, and submit a Tiny Tool Town listing from a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/tiny-tool-town-submitter/plugin.json"
+  }
+}

--- a/catalog/github/token-pacman.json
+++ b/catalog/github/token-pacman.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:token-pacman",
+  "displayName": "Token Pac-Man",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/token-pacman/plugin.json",
+  "description": "Visualize live session AI-credit usage as a Pac-Man board with pellets, ghosts, milestones, and limits in a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/token-pacman/plugin.json"
+  }
+}

--- a/catalog/github/where-was-i.json
+++ b/catalog/github/where-was-i.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:where-was-i",
+  "displayName": "Where Was I",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/where-was-i/plugin.json",
+  "description": "Reconstruct branch, commit, uncommitted-work, and pull-request context in a GitHub Copilot canvas to resume development quickly.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/where-was-i/plugin.json"
+  }
+}

--- a/catalog/github/windows-app-storage-inspector-cleanup.json
+++ b/catalog/github/windows-app-storage-inspector-cleanup.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:windows-app-storage-inspector-cleanup",
+  "displayName": "Windows App Storage Inspector Cleanup",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/windows-app-storage-inspector-cleanup/plugin.json",
+  "description": "Inspect Windows application storage, understand disk usage, and safely recycle approved cleanup items from a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/windows-app-storage-inspector-cleanup/plugin.json"
+  }
+}

--- a/catalog/github/work-hub.json
+++ b/catalog/github/work-hub.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "urn:ai:github.com:github:awesome-copilot:work-hub",
+  "displayName": "Work Hub",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/github/awesome-copilot/blob/main/plugins/work-hub/plugin.json",
+  "description": "Manage cross-repository onboarding, focus planning, repository health, work signals, and session cleanup from a GitHub Copilot canvas.",
+  "tags": [
+    "canvas",
+    "canvas-only",
+    "github-copilot"
+  ],
+  "metadata": {
+    "sourceSet": "github/awesome-copilot",
+    "repoPath": "plugins/work-hub/plugin.json"
+  }
+}

--- a/scripts/generate_ai_catalog.py
+++ b/scripts/generate_ai_catalog.py
@@ -2,7 +2,8 @@
 
 import argparse
 import json
-from pathlib import Path
+import re
+from pathlib import Path, PurePosixPath
 from urllib.error import URLError
 from urllib.parse import unquote, urlencode, urlparse
 from urllib.request import Request, urlopen
@@ -16,10 +17,90 @@ MAX_BYTES = 10 * 1024 * 1024
 MCP_CATALOG = "https://api.mcp.github.com/.well-known/ai-catalog.json"
 MCP_REGISTRY = "https://api.mcp.github.com/v0.1/servers"
 MCP_REGISTRY_PAGE_SIZE = 100
+CANVAS_PLUGIN_MEDIA_TYPE = "application/vnd.github.copilot-plugin"
+CANVAS_ONLY_REQUIRED_TAGS = frozenset(("canvas", "canvas-only", "github-copilot"))
+NON_CANVAS_PLUGIN_TAGS = frozenset(("agent", "hook", "mcp-server", "skill"))
+SOURCE_SET_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def fail(message):
     raise SystemExit(message)
+
+
+def validate_canvas_only_tags(tags, source):
+    missing_tags = CANVAS_ONLY_REQUIRED_TAGS.difference(tags)
+    if missing_tags:
+        fail(
+            f"{source}: canvas-only entry is missing required tags "
+            f"{', '.join(sorted(missing_tags))}"
+        )
+    conflicting_tags = NON_CANVAS_PLUGIN_TAGS.intersection(tags)
+    if conflicting_tags:
+        fail(
+            f"{source}: canvas-only entry cannot include non-Canvas capability tags "
+            f"{', '.join(sorted(conflicting_tags))}"
+        )
+
+
+def validate_repository_metadata(metadata, source):
+    if metadata is None:
+        return
+    if not isinstance(metadata, dict):
+        fail(f"{source}: metadata must be an object")
+
+    source_set = metadata.get("sourceSet")
+    repo_path = metadata.get("repoPath")
+    if source_set is None and repo_path is None:
+        return
+    if (
+        not isinstance(source_set, str)
+        or not SOURCE_SET_PATTERN.fullmatch(source_set)
+        or any(part in (".", "..") for part in source_set.split("/"))
+    ):
+        fail(f"{source}: metadata.sourceSet must be an owner/repository name")
+    if not isinstance(repo_path, str) or not repo_path.strip():
+        fail(f"{source}: metadata.repoPath must be a non-empty relative path")
+    if (
+        "\\" in repo_path
+        or unquote(repo_path) != repo_path
+        or PurePosixPath(repo_path).is_absolute()
+        or any(part in ("", ".", "..") for part in repo_path.split("/"))
+    ):
+        fail(f"{source}: metadata.repoPath must be a safe relative POSIX path")
+
+
+def validate_canvas_only_source(entry, url, source):
+    metadata = entry.get("metadata")
+    if not isinstance(metadata, dict):
+        fail(f"{source}: canvas-only entry metadata must be an object")
+    source_set = metadata.get("sourceSet")
+    repo_path = metadata.get("repoPath")
+    if not isinstance(source_set, str) or not isinstance(repo_path, str):
+        fail(
+            f"{source}: canvas-only entry metadata must include sourceSet and repoPath"
+        )
+
+    decoded_path = unquote(url.path)
+    prefix = f"/{source_set}/blob/"
+    suffix = f"/{repo_path}"
+    ref_and_path = (
+        decoded_path[len(prefix) :] if decoded_path.startswith(prefix) else ""
+    )
+    if (
+        url.netloc.lower() != "github.com"
+        or unquote(decoded_path) != decoded_path
+        or "\\" in decoded_path
+        or any(part in (".", "..") for part in decoded_path.split("/"))
+        or url.query
+        or url.fragment
+        or not ref_and_path
+        or not decoded_path.endswith(suffix)
+        or len(ref_and_path) <= len(suffix)
+    ):
+        fail(
+            f"{source}: canvas-only entry url must point to metadata.repoPath "
+            f"in the metadata.sourceSet GitHub repository"
+        )
 
 
 def validate(entry, source):
@@ -42,17 +123,59 @@ def validate(entry, source):
     if has_url and (not isinstance(entry["url"], str) or not entry["url"].strip()):
         fail(f"{source}: url must be a non-empty string")
     if has_url:
-        url = urlparse(entry["url"])
-        if url.scheme not in ("http", "https") or not url.netloc:
+        try:
+            url = urlparse(entry["url"])
+            hostname = url.hostname
+            url.port
+        except ValueError:
+            fail(f"{source}: url must be a valid absolute HTTP(S) URL")
+        if (
+            url.scheme not in ("http", "https")
+            or not url.netloc
+            or not hostname
+            or "\\" in url.netloc
+        ):
             fail(f"{source}: url must be an absolute HTTP(S) URL")
+        if url.username is not None or url.password is not None:
+            fail(f"{source}: url must not contain credentials")
     if has_data and not isinstance(entry["data"], dict):
         fail(f"{source}: data must be an object")
     if not entry["identifier"].startswith("urn:ai:"):
         fail(f"{source}: identifier must start with urn:ai:")
 
     version = entry.get("version")
-    if version is not None and not isinstance(version, str):
-        fail(f"{source}: version must be a string")
+    if version is not None and (
+        not isinstance(version, str) or not version.strip()
+    ):
+        fail(f"{source}: version must be a non-empty string")
+
+    tags = entry.get("tags")
+    if tags is not None and (
+        not isinstance(tags, list)
+        or not all(isinstance(tag, str) and tag.strip() for tag in tags)
+    ):
+        fail(f"{source}: tags must be an array of non-empty strings")
+    if isinstance(tags, list) and len(tags) != len(set(tags)):
+        fail(f"{source}: tags must not contain duplicates")
+    if isinstance(tags, list) and "canvas-only" in tags:
+        validate_canvas_only_tags(tags, source)
+        if not has_url:
+            fail(f"{source}: canvas-only entries must use a GitHub descriptor url")
+        if entry.get("mediaType") != CANVAS_PLUGIN_MEDIA_TYPE:
+            fail(
+                f"{source}: canvas-only entries must use mediaType "
+                f"{CANVAS_PLUGIN_MEDIA_TYPE}"
+            )
+        entry_type = entry.get("type")
+        if entry_type is not None and entry_type != CANVAS_PLUGIN_MEDIA_TYPE:
+            fail(
+                f"{source}: canvas-only entry type must match mediaType "
+                f"{CANVAS_PLUGIN_MEDIA_TYPE}"
+            )
+
+    validate_repository_metadata(entry.get("metadata"), source)
+    if isinstance(tags, list) and "canvas-only" in tags:
+        validate_canvas_only_source(entry, url, source)
 
 
 def load_mcp_entries():

--- a/tests/test_generate_ai_catalog.py
+++ b/tests/test_generate_ai_catalog.py
@@ -9,6 +9,23 @@ from scripts import generate_ai_catalog
 
 
 class ValidateEntryTest(unittest.TestCase):
+    @staticmethod
+    def canvas_entry():
+        return {
+            "identifier": "urn:ai:example.com:test:canvas",
+            "displayName": "Test Canvas",
+            "mediaType": generate_ai_catalog.CANVAS_PLUGIN_MEDIA_TYPE,
+            "url": (
+                "https://github.com/owner/repository/blob/main/"
+                "plugins/canvas/plugin.json"
+            ),
+            "tags": sorted(generate_ai_catalog.CANVAS_ONLY_REQUIRED_TAGS),
+            "metadata": {
+                "sourceSet": "owner/repository",
+                "repoPath": "plugins/canvas/plugin.json",
+            },
+        }
+
     def test_display_name_precedence(self):
         entry = {"displayName": "owner/repo", "title": "Catalog title", "name": "server-name"}
         registry_record = {
@@ -86,6 +103,151 @@ class ValidateEntryTest(unittest.TestCase):
         generate_ai_catalog.validate(entry | {"url": "https://example.com"}, "test")
         generate_ai_catalog.validate(entry | {"data": {}}, "test")
 
+    def test_valid_canvas_only_entry(self):
+        entry = self.canvas_entry()
+        generate_ai_catalog.validate(entry, "test")
+
+    def test_canvas_only_entry_requires_each_contract_tag(self):
+        tags = generate_ai_catalog.CANVAS_ONLY_REQUIRED_TAGS
+        for missing_tag in sorted(tags):
+            with self.subTest(missing_tag=missing_tag), self.assertRaisesRegex(
+                SystemExit, rf"missing required tags {missing_tag}"
+            ):
+                generate_ai_catalog.validate_canvas_only_tags(
+                    tags - {missing_tag}, "test"
+                )
+
+    def test_canvas_only_entry_requires_generic_plugin_media_type(self):
+        with self.assertRaisesRegex(SystemExit, "must use mediaType"):
+            generate_ai_catalog.validate(
+                self.canvas_entry() | {"mediaType": "application/ai-skill"},
+                "test",
+            )
+        with self.assertRaisesRegex(SystemExit, "type must match mediaType"):
+            generate_ai_catalog.validate(
+                self.canvas_entry() | {"type": "application/ai-skill"},
+                "test",
+            )
+
+    def test_mixed_plugin_cannot_be_marked_canvas_only(self):
+        with self.assertRaisesRegex(SystemExit, "non-Canvas capability tags agent"):
+            generate_ai_catalog.validate(
+                self.canvas_entry()
+                | {
+                    "tags": [
+                        "agent",
+                        *sorted(generate_ai_catalog.CANVAS_ONLY_REQUIRED_TAGS),
+                    ]
+                },
+                "test",
+            )
+
+    def test_canvas_classification_is_not_name_based(self):
+        generate_ai_catalog.validate(
+            {
+                "identifier": "urn:ai:example.com:test:not-classified",
+                "displayName": "Canvas-only in name",
+                "mediaType": "application/ai-skill",
+                "url": "https://example.com/canvas-only",
+                "description": "Mentions a canvas without declaring the contract.",
+            },
+            "test",
+        )
+
+    def test_rejects_invalid_tags_url_and_repository_path(self):
+        entry = self.canvas_entry()
+        invalid_entries = (
+            (entry | {"tags": "canvas"}, "tags must be an array"),
+            (entry | {"tags": ["canvas", ""]}, "array of non-empty strings"),
+            (entry | {"tags": ["canvas", "canvas"]}, "must not contain duplicates"),
+            (entry | {"version": ""}, "version must be a non-empty string"),
+            (
+                entry | {"url": "https://user:secret@example.com/plugin"},
+                "must not contain credentials",
+            ),
+            (
+                entry | {"url": "https://example.com\\@attacker.test/plugin"},
+                "must be an absolute HTTP",
+            ),
+            (
+                entry | {"url": "https://[invalid/plugin"},
+                "must be a valid absolute HTTP",
+            ),
+            (
+                entry
+                | {
+                    "url": (
+                        "https://github.com:notaport/owner/repository/blob/main/"
+                        "plugins/canvas/plugin.json"
+                    )
+                },
+                "must be a valid absolute HTTP",
+            ),
+            (
+                entry
+                | {
+                    "url": (
+                        "https://github.com:99999/owner/repository/blob/main/"
+                        "plugins/canvas/plugin.json"
+                    )
+                },
+                "must be a valid absolute HTTP",
+            ),
+            (
+                entry
+                | {
+                    "url": (
+                        "https://github.com/owner/repository/blob/main/"
+                        "plugins/other/plugin.json"
+                    )
+                },
+                "must point to metadata.repoPath",
+            ),
+            (
+                entry
+                | {
+                    "metadata": {
+                        "sourceSet": "owner/repository",
+                        "repoPath": "../plugin.json",
+                    }
+                },
+                "safe relative POSIX path",
+            ),
+            (
+                entry
+                | {
+                    "metadata": {
+                        "sourceSet": "owner/repository",
+                        "repoPath": "plugins/%2e%2e/README.md",
+                    },
+                    "url": (
+                        "https://github.com/owner/repository/blob/main/"
+                        "plugins/%2e%2e/README.md"
+                    ),
+                },
+                "safe relative POSIX path",
+            ),
+            (
+                entry
+                | {
+                    "metadata": {
+                        "sourceSet": "owner/repository",
+                        "repoPath": "README.md",
+                    },
+                    "url": (
+                        "https://github.com/owner/repository/blob/main/"
+                        "plugins/%2e%2e/README.md"
+                    ),
+                },
+                "must point to metadata.repoPath",
+            ),
+        )
+        for invalid, message in invalid_entries:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                SystemExit, message
+            ):
+                generate_ai_catalog.validate(invalid, "test")
+
     def test_generated_type_falls_back_to_media_type(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -160,6 +322,137 @@ class ValidateEntryTest(unittest.TestCase):
 
         entries = json.loads(rendered)["entries"]
         self.assertEqual(entries[1]["displayName"], "Publisher display name")
+
+    def test_generation_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "catalog" / "example"
+            source.mkdir(parents=True)
+            for filename, identifier in (
+                ("zeta.json", "urn:ai:example.com:test:zeta"),
+                ("alpha.json", "urn:ai:example.com:test:alpha"),
+            ):
+                (source / filename).write_text(
+                    json.dumps(
+                        {
+                            "identifier": identifier,
+                            "displayName": filename,
+                            "mediaType": "application/ai-skill",
+                            "url": f"https://example.com/{filename}",
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+            remote_entries = [
+                {
+                    "identifier": f"urn:ai:example.com:remote:{name}",
+                    "displayName": name,
+                    "type": "application/mcp-server+json",
+                    "url": f"https://example.com/{name}",
+                }
+                for name in ("zeta", "alpha")
+            ]
+            with (
+                patch.object(generate_ai_catalog, "ROOT", root),
+                patch.object(generate_ai_catalog, "SOURCE_DIR", root / "catalog"),
+                patch.object(
+                    generate_ai_catalog,
+                    "load_mcp_entries",
+                    side_effect=[remote_entries, list(reversed(remote_entries))],
+                ),
+                patch.object(
+                    generate_ai_catalog,
+                    "load_mcp_registry_records",
+                    return_value=[],
+                ),
+            ):
+                first, _ = generate_ai_catalog.generate()
+                second, _ = generate_ai_catalog.generate()
+
+        self.assertEqual(first, second)
+
+    def test_generated_canvas_only_filter_shape(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "catalog" / "example"
+            source.mkdir(parents=True)
+            canvas = self.canvas_entry()
+            (source / "canvas.json").write_text(
+                json.dumps(canvas),
+                encoding="utf-8",
+            )
+            (source / "mixed.json").write_text(
+                json.dumps(
+                    {
+                        "identifier": "urn:ai:example.com:test:mixed",
+                        "displayName": "Mixed plugin",
+                        "mediaType": generate_ai_catalog.CANVAS_PLUGIN_MEDIA_TYPE,
+                        "url": "https://example.com/mixed",
+                        "tags": ["canvas", "github-copilot"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(generate_ai_catalog, "ROOT", root),
+                patch.object(generate_ai_catalog, "SOURCE_DIR", root / "catalog"),
+                patch.object(generate_ai_catalog, "load_mcp_entries", return_value=[]),
+            ):
+                rendered, _ = generate_ai_catalog.generate()
+
+        entries = json.loads(rendered)["entries"]
+        matches = [
+            entry
+            for entry in entries
+            if entry["type"] == generate_ai_catalog.CANVAS_PLUGIN_MEDIA_TYPE
+            and generate_ai_catalog.CANVAS_ONLY_REQUIRED_TAGS.issubset(
+                entry.get("tags", ())
+            )
+        ]
+        self.assertEqual(
+            [entry["identifier"] for entry in matches],
+            ["urn:air:example.com:test:canvas"],
+        )
+
+    def test_duplicate_entries_report_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "catalog" / "example"
+            source.mkdir(parents=True)
+            entry = {
+                "identifier": "urn:ai:example.com:test:duplicate",
+                "displayName": "Duplicate",
+                "mediaType": "application/ai-skill",
+                "url": "https://example.com/duplicate",
+            }
+            for filename in ("first.json", "second.json"):
+                (source / filename).write_text(json.dumps(entry), encoding="utf-8")
+            with (
+                patch.object(generate_ai_catalog, "ROOT", root),
+                patch.object(generate_ai_catalog, "SOURCE_DIR", root / "catalog"),
+                patch.object(generate_ai_catalog, "load_mcp_entries", return_value=[]),
+                self.assertRaisesRegex(
+                    SystemExit,
+                    r"catalog/example/second\.json: duplicate identifier/version identity",
+                ),
+            ):
+                generate_ai_catalog.generate()
+
+    def test_invalid_json_reports_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "catalog" / "example"
+            source.mkdir(parents=True)
+            (source / "invalid.json").write_text("{", encoding="utf-8")
+            with (
+                patch.object(generate_ai_catalog, "ROOT", root),
+                patch.object(generate_ai_catalog, "SOURCE_DIR", root / "catalog"),
+                patch.object(generate_ai_catalog, "load_mcp_entries", return_value=[]),
+                self.assertRaisesRegex(
+                    SystemExit, r"catalog/example/invalid\.json: invalid JSON"
+                ),
+            ):
+                generate_ai_catalog.generate()
 
     def test_load_mcp_registry_records_paginates_with_next_cursor(self):
         class FakeResponse:


### PR DESCRIPTION
## Summary

- Add 23 curated Canvas-only Agent Plugins from `github/awesome-copilot`.
- Keep the generic Agent Plugin media type and mark Canvas-only packages with validated `canvas`, `canvas-only`, and `github-copilot` tags.
- Document and test the catalogue contract, then regenerate `ai-catalog.json`.

## Why

This supplies the Canvas catalogue content needed by [App #10216](https://github.com/github/github-app/issues/10216) and epic [#1230](https://github.com/github/copilot-ecosystem/issues/1230).

Classification is explicit. Clients must not infer Canvas support from display names, descriptions, keywords, or repository labels.

Closes #25.

## Follow-up

Typed runtime/App consumption and exact installed-state correlation remain in [runtime #16831](https://github.com/github/copilot-agent-runtime/issues/16831).