### PR TITLE
Add RunOnProof agent-first MCP

### DIFF
--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -20156,7 +20156,7 @@
       "identifier": "urn:air:github.com:runonproof:cdo:agent-first-mcp",
       "displayName": "RunOnProof Agent-First MCP",
       "mediaType": "application/mcp-server+json",
-      "url": "https://github.com/runonproof/cdo/blob/main/server.json",
+      "url": "https://api.runonproof.com/.well-known/mcp/server-card.json",
       "description": "Free verifiable Agent ID and proof wallet, plus US company, supplier, invoice, payment, and vendor checks.",
       "metadata": {
         "sourceSet": "runonproof/cdo",

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -20153,6 +20153,18 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:github.com:runonproof:cdo:agent-first-mcp",
+      "displayName": "RunOnProof Agent-First MCP",
+      "mediaType": "application/mcp-server+json",
+      "url": "https://github.com/runonproof/cdo/blob/main/server.json",
+      "description": "Free verifiable Agent ID and proof wallet, plus US company, supplier, invoice, payment, and vendor checks.",
+      "metadata": {
+        "sourceSet": "runonproof/cdo",
+        "repoPath": "server.json"
+      },
+      "type": "application/mcp-server+json"
+    },
+    {
       "identifier": "urn:air:github.com:shader-slang:slang-skills:slang-analyze-coverage",
       "displayName": "Slang Analyze Coverage",
       "mediaType": "application/ai-skill",
@@ -22007,7 +22019,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:34:48Z",
+      "updatedAt": "2026-08-24T19:44:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -22022,7 +22034,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-24T18:34:49Z",
+      "updatedAt": "2026-08-24T19:44:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22047,7 +22059,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-08-24T18:34:50Z",
+      "updatedAt": "2026-08-24T19:44:19Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22062,7 +22074,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-24T18:34:51Z",
+      "updatedAt": "2026-08-24T19:44:20Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22086,7 +22098,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-24T18:34:52Z",
+      "updatedAt": "2026-08-24T19:44:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -22113,7 +22125,7 @@
         "claude-code"
       ],
       "version": "1.15.0",
-      "updatedAt": "2026-08-24T18:34:53Z",
+      "updatedAt": "2026-08-24T19:44:22Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -22137,7 +22149,7 @@
         "model-context-protocol"
       ],
       "version": "0.9.1",
-      "updatedAt": "2026-08-24T18:34:55Z",
+      "updatedAt": "2026-08-24T19:44:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -22165,7 +22177,7 @@
         "mcp-server"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-24T18:34:56Z",
+      "updatedAt": "2026-08-24T19:44:25Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -22218,7 +22230,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-24T18:34:57Z",
+      "updatedAt": "2026-08-24T19:44:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22244,7 +22256,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:34:58Z",
+      "updatedAt": "2026-08-24T19:44:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
@@ -22268,7 +22280,7 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:34:59Z",
+      "updatedAt": "2026-08-24T19:44:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
@@ -22284,7 +22296,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:00Z",
+      "updatedAt": "2026-08-24T19:44:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -22311,7 +22323,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:35:01Z",
+      "updatedAt": "2026-08-24T19:44:31Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -22407,7 +22419,7 @@
         "mcp"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-24T18:35:03Z",
+      "updatedAt": "2026-08-24T19:44:32Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22424,7 +22436,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:04Z",
+      "updatedAt": "2026-08-24T19:44:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22452,7 +22464,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-24T18:35:05Z",
+      "updatedAt": "2026-08-24T19:44:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -22515,13 +22527,13 @@
         "mcp-server"
       ],
       "version": "0.15.1",
-      "updatedAt": "2026-08-24T18:35:06Z",
+      "updatedAt": "2026-08-24T19:44:36Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4798
+        "stargazerCount": 4801
       }
     },
     {
@@ -22543,13 +22555,13 @@
         "cursor"
       ],
       "version": "1.1.3",
-      "updatedAt": "2026-08-24T18:35:08Z",
+      "updatedAt": "2026-08-24T19:44:38Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
         "repository": "https://github.com/atlassian/atlassian-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 982,
+        "stargazerCount": 983,
         "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/"
       }
     },
@@ -22560,7 +22572,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-24T18:35:09Z",
+      "updatedAt": "2026-08-24T19:44:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -22575,7 +22587,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:10Z",
+      "updatedAt": "2026-08-24T19:44:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22591,7 +22603,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:11Z",
+      "updatedAt": "2026-08-24T19:44:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22607,7 +22619,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:12Z",
+      "updatedAt": "2026-08-24T19:44:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22623,7 +22635,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:13Z",
+      "updatedAt": "2026-08-24T19:44:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22639,7 +22651,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:35:14Z",
+      "updatedAt": "2026-08-24T19:44:44Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22655,7 +22667,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:15Z",
+      "updatedAt": "2026-08-24T19:44:45Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22671,7 +22683,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:16Z",
+      "updatedAt": "2026-08-24T19:44:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22687,7 +22699,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-24T18:35:17Z",
+      "updatedAt": "2026-08-24T19:44:48Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -22701,7 +22713,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-24T18:35:18Z",
+      "updatedAt": "2026-08-24T19:44:49Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -22727,7 +22739,7 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-08-24T18:35:19Z",
+      "updatedAt": "2026-08-24T19:44:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
@@ -22755,7 +22767,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:35:21Z",
+      "updatedAt": "2026-08-24T19:44:51Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -22772,7 +22784,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-08-24T18:35:22Z",
+      "updatedAt": "2026-08-24T19:44:53Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -22786,7 +22798,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:35:23Z",
+      "updatedAt": "2026-08-24T19:44:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
@@ -22813,7 +22825,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-24T18:35:24Z",
+      "updatedAt": "2026-08-24T19:44:55Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -22829,7 +22841,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:25Z",
+      "updatedAt": "2026-08-24T19:44:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -22844,7 +22856,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:26Z",
+      "updatedAt": "2026-08-24T19:44:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -22869,7 +22881,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:27Z",
+      "updatedAt": "2026-08-24T19:44:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -22895,7 +22907,7 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-24T18:35:28Z",
+      "updatedAt": "2026-08-24T19:45:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
@@ -22911,7 +22923,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-24T18:35:29Z",
+      "updatedAt": "2026-08-24T19:45:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -22938,7 +22950,7 @@
         "technical-drawing"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:35:31Z",
+      "updatedAt": "2026-08-24T19:45:03Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -22962,7 +22974,7 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-08-24T18:35:32Z",
+      "updatedAt": "2026-08-24T19:45:04Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -22982,7 +22994,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:35:33Z",
+      "updatedAt": "2026-08-24T19:45:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23009,7 +23021,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:34Z",
+      "updatedAt": "2026-08-24T19:45:07Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -23035,7 +23047,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:35:36Z",
+      "updatedAt": "2026-08-24T19:45:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
@@ -23061,7 +23073,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-24T18:35:37Z",
+      "updatedAt": "2026-08-24T19:45:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23077,14 +23089,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.37",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
       "version": "3.0.0-beta.37",
-      "updatedAt": "2026-08-24T18:35:38Z",
+      "updatedAt": "2026-08-24T19:45:11Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Azure.Mcp.Server",
-        "stargazerCount": 3599,
+        "stargazerCount": 3600,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server"
       }
     },
@@ -23095,14 +23107,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.3.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
       "version": "1.3.0",
-      "updatedAt": "2026-08-24T18:35:39Z",
+      "updatedAt": "2026-08-24T19:45:12Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Fabric.Mcp.Server",
-        "stargazerCount": 3599,
+        "stargazerCount": 3600,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
       }
     },
@@ -23113,7 +23125,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-08-24T18:35:41Z",
+      "updatedAt": "2026-08-24T19:45:14Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
@@ -23130,7 +23142,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:42Z",
+      "updatedAt": "2026-08-24T19:45:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23149,7 +23161,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:35:43Z",
+      "updatedAt": "2026-08-24T19:45:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -23171,7 +23183,7 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-08-24T18:35:44Z",
+      "updatedAt": "2026-08-24T19:45:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
@@ -23194,7 +23206,7 @@
         "sports-betting"
       ],
       "version": "1.4.3",
-      "updatedAt": "2026-08-24T18:35:45Z",
+      "updatedAt": "2026-08-24T19:45:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
         "repository": "https://github.com/negative-ev/negativeev-mcp",
@@ -23209,7 +23221,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:46Z",
+      "updatedAt": "2026-08-24T19:45:21Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23236,7 +23248,7 @@
         "copilot"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-24T18:35:47Z",
+      "updatedAt": "2026-08-24T19:45:22Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
@@ -23252,7 +23264,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-24T18:35:49Z",
+      "updatedAt": "2026-08-24T19:45:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23281,7 +23293,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:50Z",
+      "updatedAt": "2026-08-24T19:45:25Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23306,7 +23318,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:51Z",
+      "updatedAt": "2026-08-24T19:45:26Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23332,7 +23344,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:35:52Z",
+      "updatedAt": "2026-08-24T19:45:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23348,7 +23360,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.47.27",
-      "updatedAt": "2026-08-24T18:35:53Z",
+      "updatedAt": "2026-08-24T19:45:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23375,7 +23387,7 @@
         "static-site"
       ],
       "version": "1.3.5",
-      "updatedAt": "2026-08-24T18:35:54Z",
+      "updatedAt": "2026-08-24T19:45:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
@@ -23404,7 +23416,7 @@
         "swagger"
       ],
       "version": "0.37.0",
-      "updatedAt": "2026-08-24T18:35:56Z",
+      "updatedAt": "2026-08-24T19:45:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -23432,7 +23444,7 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-08-24T18:35:58Z",
+      "updatedAt": "2026-08-24T19:45:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -23448,7 +23460,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:35:59Z",
+      "updatedAt": "2026-08-24T19:45:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -23466,7 +23478,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-24T18:36:00Z",
+      "updatedAt": "2026-08-24T19:45:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -23483,7 +23495,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-24T18:36:01Z",
+      "updatedAt": "2026-08-24T19:45:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
@@ -23499,7 +23511,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-08-24T18:36:02Z",
+      "updatedAt": "2026-08-24T19:45:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
@@ -23524,7 +23536,7 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-08-24T18:36:03Z",
+      "updatedAt": "2026-08-24T19:45:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
@@ -23540,7 +23552,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.11.0",
       "description": "MCP server for interacting with the Supabase platform",
       "version": "0.11.0",
-      "updatedAt": "2026-08-24T18:36:04Z",
+      "updatedAt": "2026-08-24T19:45:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
@@ -23558,7 +23570,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.1.2",
-      "updatedAt": "2026-08-24T18:36:06Z",
+      "updatedAt": "2026-08-24T19:45:42Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -23574,7 +23586,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-08-24T18:36:07Z",
+      "updatedAt": "2026-08-24T19:45:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
@@ -23596,7 +23608,7 @@
         "business-critical-yes"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:36:08Z",
+      "updatedAt": "2026-08-24T19:45:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/webflow/mcp-server#readme",
@@ -23612,7 +23624,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.wix%2Fmcp/versions/1.0.2",
       "description": "A Model Context Protocol server for Wix AI tools",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:36:09Z",
+      "updatedAt": "2026-08-24T19:45:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/wix/wix-mcp#readme",
         "repository": "https://github.com/wix/wix-mcp",
@@ -23639,7 +23651,7 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:36:10Z",
+      "updatedAt": "2026-08-24T19:45:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
@@ -23665,7 +23677,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-24T18:36:11Z",
+      "updatedAt": "2026-08-24T19:45:48Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -23693,7 +23705,7 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-24T18:36:12Z",
+      "updatedAt": "2026-08-24T19:45:50Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
@@ -23728,7 +23740,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 13622
+        "stargazerCount": 13625
       }
     },
     {
@@ -23748,7 +23760,7 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:36:13Z",
+      "updatedAt": "2026-08-24T19:45:51Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
@@ -23774,7 +23786,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-08-24T18:36:15Z",
+      "updatedAt": "2026-08-24T19:45:52Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -23790,7 +23802,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.svelte%2Fmcp/versions/0.1.26",
       "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
       "version": "0.1.26",
-      "updatedAt": "2026-08-24T18:36:16Z",
+      "updatedAt": "2026-08-24T19:45:54Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/sveltejs/ai-tools/tree/HEAD/packages/mcp-stdio",
@@ -23808,7 +23820,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:36:17Z",
+      "updatedAt": "2026-08-24T19:45:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -23862,7 +23874,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-24T18:36:18Z",
+      "updatedAt": "2026-08-24T19:45:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -23912,7 +23924,7 @@
         "voice-agents"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-24T18:36:19Z",
+      "updatedAt": "2026-08-24T19:45:58Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/saaslabsco/justcall-mcp-server#readme",
@@ -23972,7 +23984,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-24T18:36:20Z",
+      "updatedAt": "2026-08-24T19:45:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24000,7 +24012,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:36:22Z",
+      "updatedAt": "2026-08-24T19:46:00Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24029,7 +24041,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:36:23Z",
+      "updatedAt": "2026-08-24T19:46:02Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24058,7 +24070,7 @@
         "ai-native"
       ],
       "version": "1.16.3",
-      "updatedAt": "2026-08-24T18:36:24Z",
+      "updatedAt": "2026-08-24T19:46:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24086,7 +24098,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-24T18:36:25Z",
+      "updatedAt": "2026-08-24T19:46:04Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24103,7 +24115,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AnimaApp%2Fanima/versions/1.0.0",
       "description": "Connect AI coding agents to Anima Playground, Figma, and your design system.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:26Z",
+      "updatedAt": "2026-08-24T19:46:06Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/AnimaApp/mcp-server-guide#readme",
@@ -24119,7 +24131,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-24T18:36:27Z",
+      "updatedAt": "2026-08-24T19:46:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24144,13 +24156,13 @@
         "mcp"
       ],
       "version": "1.7.0",
-      "updatedAt": "2026-08-24T18:36:28Z",
+      "updatedAt": "2026-08-24T19:46:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ChromeDevTools/chrome-devtools-mcp#readme",
         "repository": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 49652
+        "stargazerCount": 49654
       }
     },
     {
@@ -24160,7 +24172,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.4.1",
-      "updatedAt": "2026-08-24T18:36:30Z",
+      "updatedAt": "2026-08-24T19:46:09Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
@@ -24177,7 +24189,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-24T18:36:31Z",
+      "updatedAt": "2026-08-24T19:46:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
@@ -24200,7 +24212,7 @@
         "mcp-server"
       ],
       "version": "0.17.0",
-      "updatedAt": "2026-08-24T18:36:32Z",
+      "updatedAt": "2026-08-24T19:46:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/CrowdStrike/falcon-mcp#readme",
@@ -24228,7 +24240,7 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-24T18:36:34Z",
+      "updatedAt": "2026-08-24T19:46:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
@@ -24254,7 +24266,7 @@
         "scaffolding"
       ],
       "version": "15.5.1",
-      "updatedAt": "2026-08-24T18:36:36Z",
+      "updatedAt": "2026-08-24T19:46:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24282,7 +24294,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-24T18:36:37Z",
+      "updatedAt": "2026-08-24T19:46:17Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24298,7 +24310,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-08-24T18:36:38Z",
+      "updatedAt": "2026-08-24T19:46:19Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
@@ -24327,7 +24339,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:40Z",
+      "updatedAt": "2026-08-24T19:46:20Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -24355,7 +24367,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-24T18:36:41Z",
+      "updatedAt": "2026-08-24T19:46:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24374,7 +24386,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:36:42Z",
+      "updatedAt": "2026-08-24T19:46:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24389,7 +24401,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
       "version": "0.8.0",
-      "updatedAt": "2026-08-24T18:36:43Z",
+      "updatedAt": "2026-08-24T19:46:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
@@ -24406,7 +24418,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.PagerDuty%2Fpagerduty-mcp/versions/0.2.1",
       "description": "PagerDuty's official MCP server which provides tools to interact with your PagerDuty account.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-24T18:36:44Z",
+      "updatedAt": "2026-08-24T19:46:25Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/PagerDuty/pagerduty-mcp-server#readme",
@@ -24434,7 +24446,7 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.11",
-      "updatedAt": "2026-08-24T18:36:45Z",
+      "updatedAt": "2026-08-24T19:46:26Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
@@ -24451,7 +24463,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-24T18:36:46Z",
+      "updatedAt": "2026-08-24T19:46:28Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24473,7 +24485,7 @@
         "ui5"
       ],
       "version": "1.11.13",
-      "updatedAt": "2026-08-24T18:36:48Z",
+      "updatedAt": "2026-08-24T19:46:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SAP/open-ux-tools/tree/HEAD/packages/fiori-mcp-server",
@@ -24495,7 +24507,7 @@
         "webcrawler"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:36:49Z",
+      "updatedAt": "2026-08-24T19:46:30Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ScrapeGraphAI/scrapegraph-mcp#readme",
@@ -24523,7 +24535,7 @@
         "mcp-tools"
       ],
       "version": "1.6.1",
-      "updatedAt": "2026-08-24T18:36:50Z",
+      "updatedAt": "2026-08-24T19:46:32Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
@@ -24551,13 +24563,13 @@
         "static-analysis"
       ],
       "version": "1.21.0",
-      "updatedAt": "2026-08-24T18:36:51Z",
+      "updatedAt": "2026-08-24T19:46:34Z",
       "metadata": {
         "primaryLanguage": "Java",
         "readmeUrl": "https://github.com/SonarSource/sonarqube-mcp-server#readme",
         "repository": "https://github.com/SonarSource/sonarqube-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 631
+        "stargazerCount": 632
       }
     },
     {
@@ -24574,7 +24586,7 @@
         "mcp-server"
       ],
       "version": "0.2.18",
-      "updatedAt": "2026-08-24T18:36:53Z",
+      "updatedAt": "2026-08-24T19:46:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/mcp-server#readme",
@@ -24598,7 +24610,7 @@
         "webcomponent"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-24T18:36:54Z",
+      "updatedAt": "2026-08-24T19:46:36Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/webcomponents-mcp-server#readme",
@@ -24625,7 +24637,7 @@
         "mcp"
       ],
       "version": "2.2.0",
-      "updatedAt": "2026-08-24T18:36:56Z",
+      "updatedAt": "2026-08-24T19:46:38Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -24642,7 +24654,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.0",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
       "version": "1.30.0",
-      "updatedAt": "2026-08-24T18:36:57Z",
+      "updatedAt": "2026-08-24T19:46:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -24665,7 +24677,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-24T18:36:58Z",
+      "updatedAt": "2026-08-24T19:46:41Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -24693,7 +24705,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-24T18:37:00Z",
+      "updatedAt": "2026-08-24T19:46:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -24721,7 +24733,7 @@
         "ai-agents"
       ],
       "version": "0.18.0",
-      "updatedAt": "2026-08-24T18:37:01Z",
+      "updatedAt": "2026-08-24T19:46:43Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -24750,7 +24762,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-08-24T18:37:02Z",
+      "updatedAt": "2026-08-24T19:46:45Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -24767,7 +24779,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-08-24T18:37:03Z",
+      "updatedAt": "2026-08-24T19:46:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -24796,7 +24808,7 @@
         "knowlege-graph"
       ],
       "version": "0.23.0",
-      "updatedAt": "2026-08-24T18:37:04Z",
+      "updatedAt": "2026-08-24T19:46:47Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
@@ -24824,7 +24836,7 @@
         "data-extraction"
       ],
       "version": "2.11.1",
-      "updatedAt": "2026-08-24T18:37:06Z",
+      "updatedAt": "2026-08-24T19:46:48Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
@@ -24852,7 +24864,7 @@
         "sqlserver"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-24T18:37:07Z",
+      "updatedAt": "2026-08-24T19:46:50Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
@@ -24880,7 +24892,7 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:08Z",
+      "updatedAt": "2026-08-24T19:46:51Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
@@ -24908,7 +24920,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:37:09Z",
+      "updatedAt": "2026-08-24T19:46:52Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -24937,7 +24949,7 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-24T18:37:11Z",
+      "updatedAt": "2026-08-24T19:46:54Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
@@ -24963,7 +24975,7 @@
         "gemini-cli-extension"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-08-24T18:37:12Z",
+      "updatedAt": "2026-08-24T19:46:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
@@ -24980,7 +24992,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-24T18:37:13Z",
+      "updatedAt": "2026-08-24T19:46:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25008,7 +25020,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.3",
-      "updatedAt": "2026-08-24T18:37:14Z",
+      "updatedAt": "2026-08-24T19:46:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -25033,7 +25045,7 @@
         "copilot"
       ],
       "version": "2.1.2",
-      "updatedAt": "2026-08-24T18:37:15Z",
+      "updatedAt": "2026-08-24T19:46:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/Dynatrace-mcp#readme",
@@ -25049,7 +25061,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2Fdynatrace-managed-mcp/versions/1.0.1",
       "description": "MCP server for Dynatrace Managed to access logs, events, and metrics.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:37:17Z",
+      "updatedAt": "2026-08-24T19:47:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -25065,7 +25077,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-08-24T18:37:18Z",
+      "updatedAt": "2026-08-24T19:47:01Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
@@ -25081,7 +25093,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-08-24T18:37:19Z",
+      "updatedAt": "2026-08-24T19:47:03Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -25101,14 +25113,14 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-08-24T18:37:20Z",
+      "updatedAt": "2026-08-24T19:47:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/getsentry/sentry-mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 827
+        "stargazerCount": 828
       }
     },
     {
@@ -25123,13 +25135,13 @@
         "mcp-server"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-24T18:37:21Z",
+      "updatedAt": "2026-08-24T19:47:06Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32466
+        "stargazerCount": 32469
       }
     },
     {
@@ -25144,7 +25156,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-24T18:37:23Z",
+      "updatedAt": "2026-08-24T19:47:07Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -25160,7 +25172,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:25Z",
+      "updatedAt": "2026-08-24T19:47:09Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
@@ -25188,7 +25200,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:37:26Z",
+      "updatedAt": "2026-08-24T19:47:10Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -25213,7 +25225,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.46.0",
-      "updatedAt": "2026-08-24T18:37:27Z",
+      "updatedAt": "2026-08-24T19:47:11Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
@@ -25241,7 +25253,7 @@
         "privacy"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-24T18:37:29Z",
+      "updatedAt": "2026-08-24T19:47:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
@@ -25269,7 +25281,7 @@
         "rag"
       ],
       "version": "4.13.3",
-      "updatedAt": "2026-08-24T18:37:31Z",
+      "updatedAt": "2026-08-24T19:47:15Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
@@ -25296,7 +25308,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:37:33Z",
+      "updatedAt": "2026-08-24T19:47:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -25311,7 +25323,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.0",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.0",
-      "updatedAt": "2026-08-24T18:37:34Z",
+      "updatedAt": "2026-08-24T19:47:18Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25327,7 +25339,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-08-24T18:37:35Z",
+      "updatedAt": "2026-08-24T19:47:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
@@ -25343,7 +25355,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-08-24T18:37:36Z",
+      "updatedAt": "2026-08-24T19:47:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
@@ -25359,7 +25371,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:37Z",
+      "updatedAt": "2026-08-24T19:47:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
@@ -25380,7 +25392,7 @@
         "mcp-server"
       ],
       "version": "1.0.2026082402",
-      "updatedAt": "2026-08-24T18:37:39Z",
+      "updatedAt": "2026-08-24T19:47:24Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -25397,7 +25409,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:37:41Z",
+      "updatedAt": "2026-08-24T19:47:26Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
@@ -25425,7 +25437,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.5",
-      "updatedAt": "2026-08-24T18:37:43Z",
+      "updatedAt": "2026-08-24T19:47:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25454,7 +25466,7 @@
         "mcp"
       ],
       "version": "0.8.8",
-      "updatedAt": "2026-08-24T18:37:44Z",
+      "updatedAt": "2026-08-24T19:47:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -25478,7 +25490,7 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-08-24T18:37:45Z",
+      "updatedAt": "2026-08-24T19:47:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
@@ -25506,14 +25518,14 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-08-24T18:37:46Z",
+      "updatedAt": "2026-08-24T19:47:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
         "repository": "https://github.com/netdata/netdata",
         "repositorySource": "github",
         "repositorySubfolder": "docs/netdata-ai/mcp",
-        "stargazerCount": 80277,
+        "stargazerCount": 80278,
         "websiteUrl": "https://www.netdata.cloud"
       }
     },
@@ -25524,7 +25536,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:48Z",
+      "updatedAt": "2026-08-24T19:47:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -25552,13 +25564,13 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:37:49Z",
+      "updatedAt": "2026-08-24T19:47:35Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
         "repository": "https://github.com/oleksiijko/pmb",
         "repositorySource": "github",
-        "stargazerCount": 296
+        "stargazerCount": 297
       }
     },
     {
@@ -25580,7 +25592,7 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:50Z",
+      "updatedAt": "2026-08-24T19:47:36Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
@@ -25596,7 +25608,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
       "version": "0.2.0",
-      "updatedAt": "2026-08-24T18:37:51Z",
+      "updatedAt": "2026-08-24T19:47:38Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -25613,7 +25625,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-08-24T18:37:52Z",
+      "updatedAt": "2026-08-24T19:47:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -25629,7 +25641,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.46.4",
-      "updatedAt": "2026-08-24T18:37:53Z",
+      "updatedAt": "2026-08-24T19:47:40Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
@@ -25658,7 +25670,7 @@
         "ucg-fiber"
       ],
       "version": "0.21.1",
-      "updatedAt": "2026-08-24T18:37:54Z",
+      "updatedAt": "2026-08-24T19:47:42Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
@@ -25683,7 +25695,7 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:37:56Z",
+      "updatedAt": "2026-08-24T19:47:43Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
@@ -25711,7 +25723,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:37:57Z",
+      "updatedAt": "2026-08-24T19:47:44Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -25735,7 +25747,7 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-08-24T18:37:58Z",
+      "updatedAt": "2026-08-24T19:47:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
@@ -25752,7 +25764,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:37:59Z",
+      "updatedAt": "2026-08-24T19:47:47Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -25780,7 +25792,7 @@
         "mcp"
       ],
       "version": "6.0.0",
-      "updatedAt": "2026-08-24T18:38:00Z",
+      "updatedAt": "2026-08-24T19:47:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
@@ -25796,7 +25808,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:38:02Z",
+      "updatedAt": "2026-08-24T19:47:50Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -25816,7 +25828,7 @@
         "sas-osp"
       ],
       "version": "1.11.1",
-      "updatedAt": "2026-08-24T18:38:03Z",
+      "updatedAt": "2026-08-24T19:47:51Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
@@ -25844,7 +25856,7 @@
         "x402"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-24T18:38:05Z",
+      "updatedAt": "2026-08-24T19:47:52Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
@@ -25861,7 +25873,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.1",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:06Z",
+      "updatedAt": "2026-08-24T19:47:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
@@ -25889,7 +25901,7 @@
         "semantic-scholar"
       ],
       "version": "1.7.3",
-      "updatedAt": "2026-08-24T18:38:07Z",
+      "updatedAt": "2026-08-24T19:47:55Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
@@ -25905,7 +25917,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-24T18:38:08Z",
+      "updatedAt": "2026-08-24T19:47:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -25922,7 +25934,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-24T18:38:09Z",
+      "updatedAt": "2026-08-24T19:47:57Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -25938,7 +25950,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-08-24T18:38:10Z",
+      "updatedAt": "2026-08-24T19:47:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -25965,7 +25977,7 @@
         "stackql"
       ],
       "version": "0.10.605",
-      "updatedAt": "2026-08-24T18:38:11Z",
+      "updatedAt": "2026-08-24T19:48:00Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
@@ -25990,7 +26002,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:12Z",
+      "updatedAt": "2026-08-24T19:48:01Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -26007,7 +26019,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-08-24T18:38:13Z",
+      "updatedAt": "2026-08-24T19:48:02Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
@@ -26035,7 +26047,7 @@
         "anti-ui-slop"
       ],
       "version": "3.0.0",
-      "updatedAt": "2026-08-24T18:38:14Z",
+      "updatedAt": "2026-08-24T19:48:03Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
@@ -26058,13 +26070,13 @@
         "vibe-coding"
       ],
       "version": "1.0.31",
-      "updatedAt": "2026-08-24T18:38:16Z",
+      "updatedAt": "2026-08-24T19:48:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
         "repository": "https://github.com/upstash/context7",
         "repositorySource": "github",
-        "stargazerCount": 61155
+        "stargazerCount": 61158
       }
     },
     {
@@ -26074,7 +26086,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-08-24T18:38:17Z",
+      "updatedAt": "2026-08-24T19:48:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -26097,7 +26109,7 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-08-24T18:38:18Z",
+      "updatedAt": "2026-08-24T19:48:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
@@ -26125,7 +26137,7 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-24T18:38:19Z",
+      "updatedAt": "2026-08-24T19:48:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
@@ -26152,7 +26164,7 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.47",
-      "updatedAt": "2026-08-24T18:38:20Z",
+      "updatedAt": "2026-08-24T19:48:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
@@ -26171,7 +26183,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-24T18:38:22Z",
+      "updatedAt": "2026-08-24T19:48:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -26187,7 +26199,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.52",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
       "version": "2.1.52",
-      "updatedAt": "2026-08-24T18:38:23Z",
+      "updatedAt": "2026-08-24T19:48:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
@@ -26215,7 +26227,7 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-08-24T18:38:25Z",
+      "updatedAt": "2026-08-24T19:48:15Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
@@ -26232,7 +26244,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
       "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-24T18:38:26Z",
+      "updatedAt": "2026-08-24T19:48:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -26260,7 +26272,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-24T18:38:27Z",
+      "updatedAt": "2026-08-24T19:48:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -26276,7 +26288,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-08-24T18:38:28Z",
+      "updatedAt": "2026-08-24T19:48:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -26291,7 +26303,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-08-24T18:38:29Z",
+      "updatedAt": "2026-08-24T19:48:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -26312,7 +26324,7 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-08-24T18:38:31Z",
+      "updatedAt": "2026-08-24T19:48:21Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
@@ -26328,7 +26340,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-24T18:38:32Z",
+      "updatedAt": "2026-08-24T19:48:22Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -26465,7 +26477,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 175983
+        "stargazerCount": 175995
       }
     },
     {
@@ -26572,7 +26584,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-08-24T18:38:33Z",
+      "updatedAt": "2026-08-24T19:48:23Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -26601,7 +26613,7 @@
         "typescript"
       ],
       "version": "2.3.1",
-      "updatedAt": "2026-08-24T18:38:34Z",
+      "updatedAt": "2026-08-24T19:48:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -26636,7 +26648,7 @@
         "readmeUrl": "https://github.com/oraios/serena#readme",
         "repository": "https://github.com/oraios/serena",
         "repositorySource": "github",
-        "stargazerCount": 28445
+        "stargazerCount": 28448
       }
     },
     {
@@ -26658,7 +26670,7 @@
         "rust"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-08-24T18:38:35Z",
+      "updatedAt": "2026-08-24T19:48:26Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -26687,7 +26699,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:37Z",
+      "updatedAt": "2026-08-24T19:48:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -26746,7 +26758,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-24T18:38:38Z",
+      "updatedAt": "2026-08-24T19:48:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",

--- a/catalog/runonproof/agent-first-mcp.json
+++ b/catalog/runonproof/agent-first-mcp.json
@@ -2,7 +2,7 @@
   "identifier": "urn:ai:github.com:runonproof:cdo:agent-first-mcp",
   "displayName": "RunOnProof Agent-First MCP",
   "mediaType": "application/mcp-server+json",
-  "url": "https://github.com/runonproof/cdo/blob/main/server.json",
+  "url": "https://api.runonproof.com/.well-known/mcp/server-card.json",
   "description": "Free verifiable Agent ID and proof wallet, plus US company, supplier, invoice, payment, and vendor checks.",
   "metadata": {
     "sourceSet": "runonproof/cdo",

--- a/catalog/runonproof/agent-first-mcp.json
+++ b/catalog/runonproof/agent-first-mcp.json
@@ -1,0 +1,11 @@
+{
+  "identifier": "urn:ai:github.com:runonproof:cdo:agent-first-mcp",
+  "displayName": "RunOnProof Agent-First MCP",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://github.com/runonproof/cdo/blob/main/server.json",
+  "description": "Free verifiable Agent ID and proof wallet, plus US company, supplier, invoice, payment, and vendor checks.",
+  "metadata": {
+    "sourceSet": "runonproof/cdo",
+    "repoPath": "server.json"
+  }
+}


### PR DESCRIPTION
Adds the public RunOnProof MCP server descriptor. The entry points to the publicly accessible well-known MCP server card compiled from the canonical server.json, uses the MCP server media type, and the generated ARD catalog passes the repository generator check. The source repository is private; the submitted descriptor URL itself is public and requires no authentication.