### PR TITLE
Add Perforce Agentic Gateway to Agent Finder catalog

### DIFF
--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -19656,6 +19656,15 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.perforce:perforce-agentic-gateway",
+      "displayName": "Perforce Agentic Gateway",
+      "mediaType": "application/mcp-server+json",
+      "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.perforce%2Fperforce-agentic-gateway/versions/2026.5",
+      "description": "Local MCP gateway that proxies AI clients to many MCP servers with a token-efficient code mode.",
+      "version": "2026.5",
+      "type": "application/mcp-server+json"
+    },
+    {
       "identifier": "urn:air:github.com:pinecone-io:pinecone-claude-code-plugin:assistant",
       "displayName": "Assistant",
       "mediaType": "application/ai-skill",
@@ -22398,7 +22407,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:00Z",
+      "updatedAt": "2026-08-31T18:53:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -22413,7 +22422,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-25T07:49:01Z",
+      "updatedAt": "2026-08-31T18:53:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22438,7 +22447,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-08-25T07:49:03Z",
+      "updatedAt": "2026-08-31T18:53:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22453,7 +22462,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-25T07:49:04Z",
+      "updatedAt": "2026-08-31T18:53:31Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22477,21 +22486,21 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-25T07:49:05Z",
+      "updatedAt": "2026-08-31T18:53:33Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
         "repository": "https://github.com/keenableai/keenable-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2
+        "stargazerCount": 3
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.nauro:nauro",
       "displayName": "Nauro",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.16.0",
-      "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.18.1",
+      "description": "Human Controlled Project Truth",
       "tags": [
         "agentic-ai",
         "ai-agents",
@@ -22503,14 +22512,14 @@
         "model-context-protocol",
         "claude-code"
       ],
-      "version": "1.16.0",
-      "updatedAt": "2026-08-25T07:49:06Z",
+      "version": "1.18.1",
+      "updatedAt": "2026-08-31T18:53:34Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
         "repository": "https://github.com/Nauro-AI/nauro",
         "repositorySource": "github",
-        "stargazerCount": 9,
+        "stargazerCount": 10,
         "websiteUrl": "https://nauro.ai"
       }
     },
@@ -22518,7 +22527,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.plori:plori",
       "displayName": "Plori",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.9.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.10.0",
       "description": "Create and drive plori cloud agents and workflows over MCP; each agent has its own environment.",
       "tags": [
         "ai-agents",
@@ -22527,8 +22536,8 @@
         "mcp-server",
         "model-context-protocol"
       ],
-      "version": "0.9.1",
-      "updatedAt": "2026-08-25T07:49:07Z",
+      "version": "0.10.0",
+      "updatedAt": "2026-08-31T18:53:36Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -22556,7 +22565,7 @@
         "mcp-server"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-25T07:49:08Z",
+      "updatedAt": "2026-08-31T18:53:37Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -22599,7 +22608,7 @@
         "readmeUrl": "https://github.com/antfu/nuxt-mcp#readme",
         "repository": "https://github.com/antfu/nuxt-mcp",
         "repositorySource": "github",
-        "stargazerCount": 908
+        "stargazerCount": 909
       }
     },
     {
@@ -22609,7 +22618,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-25T07:49:09Z",
+      "updatedAt": "2026-08-31T18:53:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22635,12 +22644,12 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:10Z",
+      "updatedAt": "2026-08-31T18:53:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
         "repositorySource": "github",
-        "stargazerCount": 11,
+        "stargazerCount": 14,
         "websiteUrl": "https://mcp.desktopcommander.app"
       }
     },
@@ -22659,12 +22668,12 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:11Z",
+      "updatedAt": "2026-08-31T18:53:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 203,
+        "stargazerCount": 204,
         "websiteUrl": "https://glif.app/mcp"
       }
     },
@@ -22675,7 +22684,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:12Z",
+      "updatedAt": "2026-08-31T18:53:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -22702,7 +22711,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:49:13Z",
+      "updatedAt": "2026-08-31T18:53:43Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -22724,7 +22733,7 @@
         "readmeUrl": "https://github.com/azure-ai-foundry/mcp-foundry#readme",
         "repository": "https://github.com/azure-ai-foundry/mcp-foundry",
         "repositorySource": "github",
-        "stargazerCount": 255
+        "stargazerCount": 257
       }
     },
     {
@@ -22745,7 +22754,7 @@
         "readmeUrl": "https://github.com/Azure/aks-mcp#readme",
         "repository": "https://github.com/Azure/aks-mcp",
         "repositorySource": "github",
-        "stargazerCount": 141
+        "stargazerCount": 140
       }
     },
     {
@@ -22776,15 +22785,15 @@
         "readmeUrl": "https://github.com/chroma-core/chroma-mcp#readme",
         "repository": "https://github.com/chroma-core/chroma-mcp",
         "repositorySource": "github",
-        "stargazerCount": 587
+        "stargazerCount": 588
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:cloud.dchub:mcp-server",
       "displayName": "DC Hub — Data Center & Power Intelligence",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.12.0",
-      "description": "Data-center, grid, fiber & gas infrastructure intelligence for AI agents — query and cite.",
+      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.12.2",
+      "description": "Live data-center, grid, fiber & gas infrastructure intelligence for AI agents — query and cite.",
       "tags": [
         "ai-tools",
         "anthropic",
@@ -22797,8 +22806,8 @@
         "market-intelligence",
         "mcp"
       ],
-      "version": "2.12.0",
-      "updatedAt": "2026-08-25T07:49:15Z",
+      "version": "2.12.2",
+      "updatedAt": "2026-08-31T18:53:44Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22815,7 +22824,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:15Z",
+      "updatedAt": "2026-08-31T18:53:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22843,7 +22852,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-25T07:49:17Z",
+      "updatedAt": "2026-08-31T18:53:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -22890,14 +22899,14 @@
         "readmeUrl": "https://github.com/CognitionAI/deepwiki#readme",
         "repository": "https://github.com/CognitionAI/deepwiki",
         "repositorySource": "github",
-        "stargazerCount": 88
+        "stargazerCount": 89
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.apify:apify-mcp-server",
       "displayName": "Apify",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.apify%2Fapify-mcp-server/versions/0.15.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.apify%2Fapify-mcp-server/versions/0.15.3",
       "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
       "tags": [
         "agents",
@@ -22905,14 +22914,14 @@
         "mcp",
         "mcp-server"
       ],
-      "version": "0.15.1",
-      "updatedAt": "2026-08-25T07:49:18Z",
+      "version": "0.15.3",
+      "updatedAt": "2026-08-31T18:53:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4839
+        "stargazerCount": 5508
       }
     },
     {
@@ -22934,13 +22943,13 @@
         "cursor"
       ],
       "version": "1.1.3",
-      "updatedAt": "2026-08-25T07:49:19Z",
+      "updatedAt": "2026-08-31T18:53:51Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
         "repository": "https://github.com/atlassian/atlassian-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 983,
+        "stargazerCount": 1006,
         "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/"
       }
     },
@@ -22951,7 +22960,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-25T07:49:20Z",
+      "updatedAt": "2026-08-31T18:53:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -22966,7 +22975,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:22Z",
+      "updatedAt": "2026-08-31T18:53:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22982,7 +22991,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:22Z",
+      "updatedAt": "2026-08-31T18:53:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -22998,7 +23007,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:23Z",
+      "updatedAt": "2026-08-31T18:53:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23014,7 +23023,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:25Z",
+      "updatedAt": "2026-08-31T18:53:57Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23030,7 +23039,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:26Z",
+      "updatedAt": "2026-08-31T18:53:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23046,7 +23055,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:26Z",
+      "updatedAt": "2026-08-31T18:53:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23062,7 +23071,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:27Z",
+      "updatedAt": "2026-08-31T18:54:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23078,7 +23087,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-25T07:49:29Z",
+      "updatedAt": "2026-08-31T18:54:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23092,7 +23101,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-25T07:49:30Z",
+      "updatedAt": "2026-08-31T18:54:02Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -23118,12 +23127,12 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-08-25T07:49:31Z",
+      "updatedAt": "2026-08-31T18:54:04Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://docs.chainstack.com/docs/chainstack-mcp-server"
       }
     },
@@ -23146,7 +23155,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:49:32Z",
+      "updatedAt": "2026-08-31T18:54:05Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23163,7 +23172,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-08-25T07:49:33Z",
+      "updatedAt": "2026-08-31T18:54:06Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23177,13 +23186,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:34Z",
+      "updatedAt": "2026-08-31T18:54:07Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
         "repository": "https://github.com/figma/mcp-server-guide",
         "repositorySource": "github",
-        "stargazerCount": 1919
+        "stargazerCount": 1940
       }
     },
     {
@@ -23204,7 +23213,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-25T07:49:35Z",
+      "updatedAt": "2026-08-31T18:54:08Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -23220,7 +23229,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:49:36Z",
+      "updatedAt": "2026-08-31T18:54:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -23235,7 +23244,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:49:37Z",
+      "updatedAt": "2026-08-31T18:54:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -23260,7 +23269,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:38Z",
+      "updatedAt": "2026-08-31T18:54:12Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -23286,7 +23295,7 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-25T07:49:39Z",
+      "updatedAt": "2026-08-31T18:54:13Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
@@ -23302,7 +23311,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-25T07:49:40Z",
+      "updatedAt": "2026-08-31T18:54:14Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -23329,7 +23338,7 @@
         "technical-drawing"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:49:41Z",
+      "updatedAt": "2026-08-31T18:54:15Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -23353,7 +23362,7 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-08-25T07:49:42Z",
+      "updatedAt": "2026-08-31T18:54:16Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -23373,7 +23382,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:44Z",
+      "updatedAt": "2026-08-31T18:54:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23400,13 +23409,13 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:45Z",
+      "updatedAt": "2026-08-31T18:54:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
         "repository": "https://github.com/macfax/macfax-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://macfax.com/developers"
       }
     },
@@ -23414,7 +23423,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.mailrith:mailrith",
       "displayName": "Mailrith Email Marketing",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.1.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.1.1",
       "description": "Manage Subscribers, Broadcasts, Sequences, Automations, and reporting in Mailrith.",
       "tags": [
         "ai-agents",
@@ -23425,15 +23434,14 @@
         "typescript",
         "gemini-cli-extension"
       ],
-      "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:49:46Z",
+      "version": "1.1.1",
+      "updatedAt": "2026-08-31T18:54:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/anrawool/mailrith-agent-platform",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 1,
         "websiteUrl": "https://mailrith.com/developers/mcp"
       }
     },
@@ -23452,7 +23460,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-25T07:49:47Z",
+      "updatedAt": "2026-08-31T18:54:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23465,17 +23473,17 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.microsoft:azure",
       "displayName": "Azure MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.37",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.39",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
-      "version": "3.0.0-beta.37",
-      "updatedAt": "2026-08-25T07:49:48Z",
+      "version": "3.0.0-beta.39",
+      "updatedAt": "2026-08-31T18:54:23Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Azure.Mcp.Server",
-        "stargazerCount": 3600,
+        "stargazerCount": 3628,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server"
       }
     },
@@ -23483,17 +23491,17 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.microsoft:microsoft-fabric",
       "displayName": "Microsoft Fabric MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.3.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.4.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
-      "version": "1.3.0",
-      "updatedAt": "2026-08-25T07:49:50Z",
+      "version": "1.4.0",
+      "updatedAt": "2026-08-31T18:54:25Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Fabric.Mcp.Server",
-        "stargazerCount": 3600,
+        "stargazerCount": 3628,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
       }
     },
@@ -23504,14 +23512,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-08-25T07:49:51Z",
+      "updatedAt": "2026-08-31T18:54:26Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
         "repository": "https://github.com/NuGet/Home",
         "repositorySource": "github",
         "repositorySubfolder": "mcp",
-        "stargazerCount": 1553
+        "stargazerCount": 1554
       }
     },
     {
@@ -23521,7 +23529,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:52Z",
+      "updatedAt": "2026-08-31T18:54:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23540,7 +23548,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:53Z",
+      "updatedAt": "2026-08-31T18:54:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -23562,21 +23570,21 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-08-25T07:49:54Z",
+      "updatedAt": "2026-08-31T18:54:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
         "repository": "https://github.com/mondaycom/mcp",
         "repositorySource": "github",
-        "stargazerCount": 420
+        "stargazerCount": 421
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.negativeev:bet-checker",
-      "displayName": "Negativeev Bet Checker",
+      "displayName": "NegativeEV bet checker",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.3",
-      "description": "Grade any MLB, WNBA, PGA or ATP bet against thousands of play-by-play game simulations.",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.5",
+      "description": "Grade any MLB, WNBA, PGA or ATP bet against thousands of play-by-play sims. No key, no signup.",
       "tags": [
         "claude",
         "mcp",
@@ -23584,11 +23592,11 @@
         "simulation",
         "sports-betting"
       ],
-      "version": "1.4.3",
-      "updatedAt": "2026-08-25T07:49:55Z",
+      "version": "1.4.5",
+      "updatedAt": "2026-08-31T18:54:31Z",
       "metadata": {
-        "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
-        "repository": "https://github.com/negative-ev/negativeev-mcp",
+        "readmeUrl": "https://github.com/jessejohnsohn/negativeev-mcp#readme",
+        "repository": "https://github.com/jessejohnsohn/negativeev-mcp",
         "repositorySource": "github",
         "websiteUrl": "https://negativeev.com"
       }
@@ -23600,7 +23608,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:49:56Z",
+      "updatedAt": "2026-08-31T18:54:32Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23627,13 +23635,13 @@
         "copilot"
       ],
       "version": "2.12.0",
-      "updatedAt": "2026-08-25T07:49:57Z",
+      "updatedAt": "2026-08-31T18:54:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
         "repository": "https://github.com/postmanlabs/postman-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 307
+        "stargazerCount": 310
       }
     },
     {
@@ -23643,7 +23651,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-25T07:49:58Z",
+      "updatedAt": "2026-08-31T18:54:35Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23672,7 +23680,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:00Z",
+      "updatedAt": "2026-08-31T18:54:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23697,7 +23705,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:01Z",
+      "updatedAt": "2026-08-31T18:54:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23723,7 +23731,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:50:02Z",
+      "updatedAt": "2026-08-31T18:54:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23739,7 +23747,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.47.27",
-      "updatedAt": "2026-08-25T07:50:03Z",
+      "updatedAt": "2026-08-31T18:54:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23751,7 +23759,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.shipstatic:mcp",
       "displayName": "ShipStatic",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.shipstatic%2Fmcp/versions/1.3.5",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.shipstatic%2Fmcp/versions/1.8.0",
       "description": "Deploy static websites from AI agents. Free at mcp.shipstatic.com — no install, no signup.",
       "tags": [
         "ai",
@@ -23765,14 +23773,14 @@
         "static-hosting",
         "static-site"
       ],
-      "version": "1.3.5",
-      "updatedAt": "2026-08-25T07:50:04Z",
+      "version": "1.8.0",
+      "updatedAt": "2026-08-31T18:54:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
         "repository": "https://github.com/shipstatic/mcp",
         "repositorySource": "github",
-        "stargazerCount": 6,
+        "stargazerCount": 7,
         "websiteUrl": "https://shipstatic.com"
       }
     },
@@ -23780,7 +23788,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.smartbear:smartbear-mcp",
       "displayName": "SmartBear MCP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.smartbear%2Fsmartbear-mcp/versions/0.37.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.smartbear%2Fsmartbear-mcp/versions/0.39.0",
       "description": "MCP server for AI access to SmartBear tools, including BugSnag, Reflect, Swagger, PactFlow, QTM4J.",
       "tags": [
         "bugsnag",
@@ -23794,14 +23802,14 @@
         "portal",
         "swagger"
       ],
-      "version": "0.37.0",
-      "updatedAt": "2026-08-25T07:50:05Z",
+      "version": "0.39.0",
+      "updatedAt": "2026-08-31T18:54:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
         "repository": "https://github.com/SmartBear/smartbear-mcp",
         "repositorySource": "github",
-        "stargazerCount": 43
+        "stargazerCount": 44
       }
     },
     {
@@ -23823,13 +23831,13 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-08-25T07:50:07Z",
+      "updatedAt": "2026-08-31T18:54:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
         "repository": "https://github.com/SmartBear/smartbear-mcp",
         "repositorySource": "github",
-        "stargazerCount": 43
+        "stargazerCount": 44
       }
     },
     {
@@ -23839,7 +23847,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:08Z",
+      "updatedAt": "2026-08-31T18:54:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -23857,13 +23865,13 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-25T07:50:09Z",
+      "updatedAt": "2026-08-31T18:54:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/knowledge",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developers.soracom.io/en/docs/tools/knowledge-mcp-server/"
       }
     },
@@ -23874,7 +23882,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-25T07:50:10Z",
+      "updatedAt": "2026-08-31T18:54:49Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
@@ -23890,7 +23898,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-08-25T07:50:11Z",
+      "updatedAt": "2026-08-31T18:54:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
@@ -23915,13 +23923,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-08-25T07:50:12Z",
+      "updatedAt": "2026-08-31T18:54:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
         "repository": "https://github.com/stripe/agent-toolkit",
         "repositorySource": "github",
-        "stargazerCount": 1763
+        "stargazerCount": 1782
       }
     },
     {
@@ -23931,14 +23939,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.11.0",
       "description": "MCP server for interacting with the Supabase platform",
       "version": "0.11.0",
-      "updatedAt": "2026-08-25T07:50:13Z",
+      "updatedAt": "2026-08-31T18:54:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
         "repository": "https://github.com/supabase/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server-supabase",
-        "stargazerCount": 2871,
+        "stargazerCount": 2883,
         "websiteUrl": "https://supabase.com/mcp"
       }
     },
@@ -23946,10 +23954,10 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.tallyfy:mcp-server",
       "displayName": "Tallyfy Workflow Automation",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.2.0",
       "description": "Automate tasks, processes, and approvals with AI.",
-      "version": "1.1.2",
-      "updatedAt": "2026-08-25T07:50:15Z",
+      "version": "1.2.0",
+      "updatedAt": "2026-08-31T18:54:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -23965,12 +23973,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-08-25T07:50:16Z",
+      "updatedAt": "2026-08-31T18:54:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
         "repositorySource": "github",
-        "stargazerCount": 12
+        "stargazerCount": 13
       }
     },
     {
@@ -23987,13 +23995,13 @@
         "business-critical-yes"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:50:17Z",
+      "updatedAt": "2026-08-31T18:54:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/webflow/mcp-server#readme",
         "repository": "https://github.com/webflow/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 137
+        "stargazerCount": 138
       }
     },
     {
@@ -24003,7 +24011,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.wix%2Fmcp/versions/1.0.2",
       "description": "A Model Context Protocol server for Wix AI tools",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:18Z",
+      "updatedAt": "2026-08-31T18:54:57Z",
       "metadata": {
         "readmeUrl": "https://github.com/wix/wix-mcp#readme",
         "repository": "https://github.com/wix/wix-mcp",
@@ -24030,7 +24038,7 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:50:19Z",
+      "updatedAt": "2026-08-31T18:54:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
@@ -24056,7 +24064,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:50:20Z",
+      "updatedAt": "2026-08-31T18:55:00Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -24084,13 +24092,13 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-25T07:50:21Z",
+      "updatedAt": "2026-08-31T18:55:01Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
         "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
         "repositorySource": "github",
-        "stargazerCount": 187,
+        "stargazerCount": 192,
         "websiteUrl": "https://docs.xquik.com/mcp/overview"
       }
     },
@@ -24119,7 +24127,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 13634
+        "stargazerCount": 13787
       }
     },
     {
@@ -24139,7 +24147,7 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:50:22Z",
+      "updatedAt": "2026-08-31T18:55:03Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
@@ -24165,7 +24173,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-08-25T07:50:24Z",
+      "updatedAt": "2026-08-31T18:55:04Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -24181,14 +24189,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.svelte%2Fmcp/versions/0.1.26",
       "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
       "version": "0.1.26",
-      "updatedAt": "2026-08-25T07:50:25Z",
+      "updatedAt": "2026-08-31T18:55:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/sveltejs/ai-tools/tree/HEAD/packages/mcp-stdio",
         "repository": "https://github.com/sveltejs/ai-tools",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-stdio",
-        "stargazerCount": 309,
+        "stargazerCount": 314,
         "websiteUrl": "https://svelte.dev/docs/mcp/overview"
       }
     },
@@ -24199,7 +24207,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:50:26Z",
+      "updatedAt": "2026-08-31T18:55:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -24221,7 +24229,7 @@
         "readmeUrl": "https://github.com/Doist/todoist-ai#readme",
         "repository": "https://github.com/Doist/todoist-ai",
         "repositorySource": "github",
-        "stargazerCount": 537
+        "stargazerCount": 539
       }
     },
     {
@@ -24243,7 +24251,7 @@
         "readmeUrl": "https://github.com/elastic/mcp-server-elasticsearch#readme",
         "repository": "https://github.com/elastic/mcp-server-elasticsearch",
         "repositorySource": "github",
-        "stargazerCount": 705
+        "stargazerCount": 709
       }
     },
     {
@@ -24253,7 +24261,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-25T07:50:27Z",
+      "updatedAt": "2026-08-31T18:55:08Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -24283,11 +24291,11 @@
       "version": "1.0.0",
       "updatedAt": "2026-01-14T21:44:40Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/firecrawl/firecrawl-mcp-server#readme",
         "repository": "https://github.com/firecrawl/firecrawl-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 7310
+        "stargazerCount": 7358
       }
     },
     {
@@ -24303,7 +24311,7 @@
         "voice-agents"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-25T07:50:28Z",
+      "updatedAt": "2026-08-31T18:55:09Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/saaslabsco/justcall-mcp-server#readme",
@@ -24326,7 +24334,7 @@
         "readmeUrl": "https://github.com/huggingface/hf-mcp-server#readme",
         "repository": "https://github.com/huggingface/hf-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 278
+        "stargazerCount": 288
       }
     },
     {
@@ -24363,7 +24371,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-25T07:50:29Z",
+      "updatedAt": "2026-08-31T18:55:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24391,7 +24399,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:30Z",
+      "updatedAt": "2026-08-31T18:55:12Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24420,7 +24428,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:50:31Z",
+      "updatedAt": "2026-08-31T18:55:13Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24434,7 +24442,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.frihet:erp",
       "displayName": "Frihet ERP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.frihet%2Ferp/versions/1.16.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.frihet%2Ferp/versions/1.17.0",
       "description": "AI-native ERP MCP: ES/EU fiscal compliance (VeriFactu/TicketBAI/Facturae), invoicing, tax, banking",
       "tags": [
         "ai",
@@ -24448,8 +24456,8 @@
         "business-management",
         "ai-native"
       ],
-      "version": "1.16.3",
-      "updatedAt": "2026-08-25T07:50:33Z",
+      "version": "1.17.0",
+      "updatedAt": "2026-08-31T18:55:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24477,7 +24485,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.1",
-      "updatedAt": "2026-08-25T07:50:34Z",
+      "updatedAt": "2026-08-31T18:55:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24494,7 +24502,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AnimaApp%2Fanima/versions/1.0.0",
       "description": "Connect AI coding agents to Anima Playground, Figma, and your design system.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:35Z",
+      "updatedAt": "2026-08-31T18:55:17Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/AnimaApp/mcp-server-guide#readme",
@@ -24510,7 +24518,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-25T07:50:36Z",
+      "updatedAt": "2026-08-31T18:55:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24535,13 +24543,13 @@
         "mcp"
       ],
       "version": "1.7.0",
-      "updatedAt": "2026-08-25T07:50:38Z",
+      "updatedAt": "2026-08-31T18:55:19Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ChromeDevTools/chrome-devtools-mcp#readme",
         "repository": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 49671
+        "stargazerCount": 50277
       }
     },
     {
@@ -24551,13 +24559,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.4.1",
-      "updatedAt": "2026-08-25T07:50:39Z",
+      "updatedAt": "2026-08-31T18:55:21Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
         "repository": "https://github.com/ClickHouse/mcp-clickhouse",
         "repositorySource": "github",
-        "stargazerCount": 857,
+        "stargazerCount": 862,
         "websiteUrl": "https://clickhouse.com"
       }
     },
@@ -24568,12 +24576,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-25T07:50:40Z",
+      "updatedAt": "2026-08-31T18:55:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://composio.dev"
       }
     },
@@ -24581,7 +24589,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.CrowdStrike:falcon-mcp",
       "displayName": "CrowdStrike Falcon MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.CrowdStrike%2Ffalcon-mcp/versions/0.17.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.CrowdStrike%2Ffalcon-mcp/versions/0.18.0",
       "description": "Connects AI agents with CrowdStrike Falcon for security analysis and automation.",
       "tags": [
         "ai",
@@ -24590,14 +24598,14 @@
         "mcp",
         "mcp-server"
       ],
-      "version": "0.17.0",
-      "updatedAt": "2026-08-25T07:50:41Z",
+      "version": "0.18.0",
+      "updatedAt": "2026-08-31T18:55:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/CrowdStrike/falcon-mcp#readme",
         "repository": "https://github.com/CrowdStrike/falcon-mcp",
         "repositorySource": "github",
-        "stargazerCount": 239
+        "stargazerCount": 241
       }
     },
     {
@@ -24619,20 +24627,20 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-25T07:50:44Z",
+      "updatedAt": "2026-08-31T18:55:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
         "repository": "https://github.com/Decodo/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 34
+        "stargazerCount": 35
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.IgniteUI:mcp-server",
       "displayName": "Ignite UI MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Fmcp-server/versions/15.5.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Fmcp-server/versions/15.6.0",
       "description": "Unified MCP server for Ignite UI — documentation, API, and CLI scaffolding",
       "tags": [
         "cli",
@@ -24644,8 +24652,8 @@
         "test-automation",
         "scaffolding"
       ],
-      "version": "15.5.1",
-      "updatedAt": "2026-08-25T07:50:46Z",
+      "version": "15.6.0",
+      "updatedAt": "2026-08-31T18:55:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24673,7 +24681,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-25T07:50:47Z",
+      "updatedAt": "2026-08-31T18:55:29Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24689,7 +24697,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-08-25T07:50:48Z",
+      "updatedAt": "2026-08-31T18:55:30Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
@@ -24718,7 +24726,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:50Z",
+      "updatedAt": "2026-08-31T18:55:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -24746,7 +24754,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-25T07:50:51Z",
+      "updatedAt": "2026-08-31T18:55:33Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24765,7 +24773,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:52Z",
+      "updatedAt": "2026-08-31T18:55:35Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24779,14 +24787,18 @@
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
+      "tags": [
+        "mcp-server",
+        "voice-assistant"
+      ],
       "version": "0.8.0",
-      "updatedAt": "2026-08-25T07:50:53Z",
+      "updatedAt": "2026-08-31T18:55:36Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
         "repository": "https://github.com/Omnidim/omnidim-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 6,
+        "stargazerCount": 7,
         "websiteUrl": "https://omnidim.io"
       }
     },
@@ -24797,7 +24809,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.PagerDuty%2Fpagerduty-mcp/versions/0.2.1",
       "description": "PagerDuty's official MCP server which provides tools to interact with your PagerDuty account.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-25T07:50:54Z",
+      "updatedAt": "2026-08-31T18:55:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/PagerDuty/pagerduty-mcp-server#readme",
@@ -24825,13 +24837,13 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.11",
-      "updatedAt": "2026-08-25T07:50:55Z",
+      "updatedAt": "2026-08-31T18:55:38Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
         "repository": "https://github.com/pascalebeier/hitkeep",
         "repositorySource": "github",
-        "stargazerCount": 83,
+        "stargazerCount": 85,
         "websiteUrl": "https://hitkeep.com/use-cases/read-only-mcp-server-web-analytics/"
       }
     },
@@ -24842,7 +24854,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-25T07:50:56Z",
+      "updatedAt": "2026-08-31T18:55:40Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24855,7 +24867,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.SAP:fiori-mcp-server",
       "displayName": "SAP Fiori",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.SAP%2Ffiori-mcp-server/versions/1.11.13",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.SAP%2Ffiori-mcp-server/versions/1.12.0",
       "description": "SAP Fiori - Model Context Protocol (MCP) server",
       "tags": [
         "fiori",
@@ -24863,8 +24875,8 @@
         "fiori-tools",
         "ui5"
       ],
-      "version": "1.11.13",
-      "updatedAt": "2026-08-25T07:50:58Z",
+      "version": "1.12.0",
+      "updatedAt": "2026-08-31T18:55:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SAP/open-ux-tools/tree/HEAD/packages/fiori-mcp-server",
@@ -24886,13 +24898,13 @@
         "webcrawler"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:50:59Z",
+      "updatedAt": "2026-08-31T18:55:43Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ScrapeGraphAI/scrapegraph-mcp#readme",
         "repository": "https://github.com/ScrapeGraphAI/scrapegraph-mcp",
         "repositorySource": "github",
-        "stargazerCount": 96
+        "stargazerCount": 100
       }
     },
     {
@@ -24914,14 +24926,14 @@
         "mcp-tools"
       ],
       "version": "1.6.1",
-      "updatedAt": "2026-08-25T07:51:00Z",
+      "updatedAt": "2026-08-31T18:55:44Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
         "repository": "https://github.com/Sendmux/sendmux-sdk",
         "repositorySource": "github",
         "repositorySubfolder": "packages/python/mcp",
-        "stargazerCount": 78,
+        "stargazerCount": 73,
         "websiteUrl": "https://sendmux.ai/docs/guides/mcp"
       }
     },
@@ -24942,13 +24954,13 @@
         "static-analysis"
       ],
       "version": "1.21.0",
-      "updatedAt": "2026-08-25T07:51:01Z",
+      "updatedAt": "2026-08-31T18:55:46Z",
       "metadata": {
         "primaryLanguage": "Java",
         "readmeUrl": "https://github.com/SonarSource/sonarqube-mcp-server#readme",
         "repository": "https://github.com/SonarSource/sonarqube-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 632
+        "stargazerCount": 635
       }
     },
     {
@@ -24965,13 +24977,13 @@
         "mcp-server"
       ],
       "version": "0.2.18",
-      "updatedAt": "2026-08-25T07:51:02Z",
+      "updatedAt": "2026-08-31T18:55:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/mcp-server#readme",
         "repository": "https://github.com/UI5/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 98
+        "stargazerCount": 99
       }
     },
     {
@@ -24989,7 +25001,7 @@
         "webcomponent"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-25T07:51:04Z",
+      "updatedAt": "2026-08-31T18:55:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/webcomponents-mcp-server#readme",
@@ -25002,27 +25014,28 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Vortx-AI:emem",
       "displayName": "emem, the verifiable memory protocol for the physical world",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.2.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.3.0",
       "description": "Shared memory for AI agents. One address per fact, one signature you check. No key to read.",
       "tags": [
         "long-term-memory",
-        "world-models",
-        "earth-observation",
-        "long-running-agents",
-        "multi-agent",
         "shared-memory",
-        "substrate",
         "a2a-protocol",
-        "mcp"
+        "mcp",
+        "agent-interoperability",
+        "agent-memory",
+        "ai-agents",
+        "content-addressed",
+        "earth-orientation",
+        "ed25519"
       ],
-      "version": "2.2.0",
-      "updatedAt": "2026-08-25T07:51:05Z",
+      "version": "2.3.0",
+      "updatedAt": "2026-08-31T18:55:50Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
         "repository": "https://github.com/Vortx-AI/emem",
         "repositorySource": "github",
-        "stargazerCount": 54,
+        "stargazerCount": 56,
         "websiteUrl": "https://emem.dev"
       }
     },
@@ -25033,7 +25046,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.0",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
       "version": "1.30.0",
-      "updatedAt": "2026-08-25T07:51:06Z",
+      "updatedAt": "2026-08-31T18:55:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -25056,7 +25069,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-25T07:51:07Z",
+      "updatedAt": "2026-08-31T18:55:53Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -25084,7 +25097,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-25T07:51:08Z",
+      "updatedAt": "2026-08-31T18:55:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -25097,7 +25110,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.agentic-hil:agentic-hil",
       "displayName": "Agentic HIL",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.18.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.20.0",
       "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
       "tags": [
         "embedded",
@@ -25111,8 +25124,8 @@
         "stlink",
         "ai-agents"
       ],
-      "version": "0.18.0",
-      "updatedAt": "2026-08-25T07:51:09Z",
+      "version": "0.20.0",
+      "updatedAt": "2026-08-31T18:55:56Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -25141,7 +25154,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-08-25T07:51:11Z",
+      "updatedAt": "2026-08-31T18:55:58Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -25158,7 +25171,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-08-25T07:51:12Z",
+      "updatedAt": "2026-08-31T18:55:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -25172,7 +25185,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.basicmachines-co:basic-memory",
       "displayName": "Basicmachines Co Basic Memory",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.basicmachines-co%2Fbasic-memory/versions/0.23.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.basicmachines-co%2Fbasic-memory/versions/0.23.2",
       "description": "Local-first knowledge management with bi-directional LLM sync via Markdown files.",
       "tags": [
         "ai",
@@ -25186,14 +25199,14 @@
         "knowledge-management",
         "knowlege-graph"
       ],
-      "version": "0.23.0",
-      "updatedAt": "2026-08-25T07:51:13Z",
+      "version": "0.23.2",
+      "updatedAt": "2026-08-31T18:56:00Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
         "repository": "https://github.com/basicmachines-co/basic-memory.git",
         "repositorySource": "github",
-        "stargazerCount": 3752
+        "stargazerCount": 3819
       }
     },
     {
@@ -25215,13 +25228,13 @@
         "data-extraction"
       ],
       "version": "2.11.1",
-      "updatedAt": "2026-08-25T07:51:14Z",
+      "updatedAt": "2026-08-31T18:56:02Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
         "repository": "https://github.com/brightdata/brightdata-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2611
+        "stargazerCount": 2619
       }
     },
     {
@@ -25243,13 +25256,13 @@
         "sqlserver"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-25T07:51:15Z",
+      "updatedAt": "2026-08-31T18:56:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
         "repository": "https://github.com/bytebase/dbhub",
         "repositorySource": "github",
-        "stargazerCount": 3395
+        "stargazerCount": 3436
       }
     },
     {
@@ -25271,13 +25284,13 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:17Z",
+      "updatedAt": "2026-08-31T18:56:05Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
         "repository": "https://github.com/cap-js/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 109
+        "stargazerCount": 110
       }
     },
     {
@@ -25299,7 +25312,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:51:18Z",
+      "updatedAt": "2026-08-31T18:56:06Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -25328,13 +25341,13 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-25T07:51:19Z",
+      "updatedAt": "2026-08-31T18:56:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
         "repository": "https://github.com/cometchat/docs-mcp",
         "repositorySource": "github",
-        "stargazerCount": 60,
+        "stargazerCount": 65,
         "websiteUrl": "https://www.cometchat.com/docs/mcp-server"
       }
     },
@@ -25354,13 +25367,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-08-25T07:51:20Z",
+      "updatedAt": "2026-08-31T18:56:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
         "repository": "https://github.com/contextstream/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 38,
+        "stargazerCount": 40,
         "websiteUrl": "https://contextstream.io/docs/mcp"
       }
     },
@@ -25371,7 +25384,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-25T07:51:21Z",
+      "updatedAt": "2026-08-31T18:56:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25384,7 +25397,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.dsers:dsers-mcp-server",
       "displayName": "DSers Official MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dsers%2Fdsers-mcp-server/versions/1.8.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dsers%2Fdsers-mcp-server/versions/1.8.4",
       "description": "Official DSers MCP for dropshipping: import, edit, price, and publish products to Shopify and Wix.",
       "tags": [
         "1688",
@@ -25398,8 +25411,8 @@
         "mcp",
         "model-context-protocol"
       ],
-      "version": "1.8.3",
-      "updatedAt": "2026-08-25T07:51:22Z",
+      "version": "1.8.4",
+      "updatedAt": "2026-08-31T18:56:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -25424,13 +25437,13 @@
         "copilot"
       ],
       "version": "2.1.2",
-      "updatedAt": "2026-08-25T07:51:23Z",
+      "updatedAt": "2026-08-31T18:56:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/Dynatrace-mcp#readme",
         "repository": "https://github.com/dynatrace-oss/Dynatrace-mcp",
         "repositorySource": "github",
-        "stargazerCount": 134
+        "stargazerCount": 136
       }
     },
     {
@@ -25440,7 +25453,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2Fdynatrace-managed-mcp/versions/1.0.1",
       "description": "MCP server for Dynatrace Managed to access logs, events, and metrics.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:51:25Z",
+      "updatedAt": "2026-08-31T18:56:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -25456,7 +25469,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-08-25T07:51:26Z",
+      "updatedAt": "2026-08-31T18:56:15Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
@@ -25472,7 +25485,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-08-25T07:51:27Z",
+      "updatedAt": "2026-08-31T18:56:17Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -25492,35 +25505,35 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-08-25T07:51:28Z",
+      "updatedAt": "2026-08-31T18:56:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/getsentry/sentry-mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 828
+        "stargazerCount": 837
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.github:github-mcp-server",
       "displayName": "GitHub",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.github%2Fgithub-mcp-server/versions/1.10.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.github%2Fgithub-mcp-server/versions/1.11.0",
       "description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",
       "tags": [
         "github",
         "mcp",
         "mcp-server"
       ],
-      "version": "1.10.1",
-      "updatedAt": "2026-08-25T07:51:29Z",
+      "version": "1.11.0",
+      "updatedAt": "2026-08-31T18:56:20Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32486
+        "stargazerCount": 32626
       }
     },
     {
@@ -25535,7 +25548,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:51:31Z",
+      "updatedAt": "2026-08-31T18:56:22Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -25551,13 +25564,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:32Z",
+      "updatedAt": "2026-08-31T18:56:24Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
         "repository": "https://github.com/hashicorp/terraform-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1512
+        "stargazerCount": 1515
       }
     },
     {
@@ -25579,7 +25592,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:51:33Z",
+      "updatedAt": "2026-08-31T18:56:25Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -25592,7 +25605,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.hostinger:hostinger-api-mcp",
       "displayName": "Hostinger API",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.47.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.52.0",
       "description": "MCP server for Hostinger API",
       "tags": [
         "ai",
@@ -25603,21 +25616,21 @@
         "mcp",
         "gemini-cli-extension"
       ],
-      "version": "1.47.0",
-      "updatedAt": "2026-08-25T07:51:34Z",
+      "version": "1.52.0",
+      "updatedAt": "2026-08-31T18:56:26Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
         "repository": "https://github.com/hostinger/api-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 142
+        "stargazerCount": 149
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.ihor-sokoliuk:mcp-searxng",
       "displayName": "SearXNG Search",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/2.0.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/2.1.0",
       "description": "MCP server for SearXNG — privacy-respecting web search with pagination, URL reading",
       "tags": [
         "ai",
@@ -25631,21 +25644,21 @@
         "cursor",
         "privacy"
       ],
-      "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:51:36Z",
+      "version": "2.1.0",
+      "updatedAt": "2026-08-31T18:56:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
         "repository": "https://github.com/ihor-sokoliuk/mcp-searxng",
         "repositorySource": "github",
-        "stargazerCount": 1158
+        "stargazerCount": 1181
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.jagoff:memo",
       "displayName": "memo",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.13.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.14.10",
       "description": "Memory for AI agents — MLX (Apple Silicon) or CPU (Linux), sqlite-vec + BM25, zero cloud.",
       "tags": [
         "apple-silicon",
@@ -25659,14 +25672,14 @@
         "qwen",
         "rag"
       ],
-      "version": "4.13.3",
-      "updatedAt": "2026-08-25T07:51:37Z",
+      "version": "4.14.10",
+      "updatedAt": "2026-08-31T18:56:32Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
         "repository": "https://github.com/jagoff/memo",
         "repositorySource": "github",
-        "stargazerCount": 14
+        "stargazerCount": 16
       }
     },
     {
@@ -25687,7 +25700,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:51:39Z",
+      "updatedAt": "2026-08-31T18:56:35Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -25702,7 +25715,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.1",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.1",
-      "updatedAt": "2026-08-25T07:51:40Z",
+      "updatedAt": "2026-08-31T18:56:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25718,13 +25731,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-08-25T07:51:41Z",
+      "updatedAt": "2026-08-31T18:56:38Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
         "repository": "https://github.com/mapbox/mcp-devkit-server",
         "repositorySource": "github",
-        "stargazerCount": 59
+        "stargazerCount": 60
       }
     },
     {
@@ -25734,13 +25747,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-08-25T07:51:42Z",
+      "updatedAt": "2026-08-31T18:56:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
         "repository": "https://github.com/mapbox/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 352
+        "stargazerCount": 353
       }
     },
     {
@@ -25750,19 +25763,19 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:43Z",
+      "updatedAt": "2026-08-31T18:56:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
         "repositorySource": "github",
-        "stargazerCount": 49
+        "stargazerCount": 52
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.microsoft:awesome-copilot",
       "displayName": "Awesome Copilot MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026082505",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026083107",
       "description": "An MCP server that stores Copilot customizations from the Awesome Copilot repository",
       "tags": [
         "dotnet",
@@ -25770,8 +25783,8 @@
         "mcp-client",
         "mcp-server"
       ],
-      "version": "1.0.2026082505",
-      "updatedAt": "2026-08-25T07:51:45Z",
+      "version": "1.0.2026083107",
+      "updatedAt": "2026-08-31T18:56:43Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -25788,13 +25801,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:51:47Z",
+      "updatedAt": "2026-08-31T18:56:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
         "repository": "https://github.com/miroapp/miro-ai",
         "repositorySource": "github",
-        "stargazerCount": 149
+        "stargazerCount": 151
       }
     },
     {
@@ -25816,7 +25829,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.5",
-      "updatedAt": "2026-08-25T07:51:48Z",
+      "updatedAt": "2026-08-31T18:56:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25845,7 +25858,7 @@
         "mcp"
       ],
       "version": "0.8.8",
-      "updatedAt": "2026-08-25T07:51:49Z",
+      "updatedAt": "2026-08-31T18:56:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -25869,13 +25882,13 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-08-25T07:51:50Z",
+      "updatedAt": "2026-08-31T18:56:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
         "repository": "https://github.com/mongodb-js/mongodb-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1106
+        "stargazerCount": 1116
       }
     },
     {
@@ -25897,14 +25910,14 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-08-25T07:51:51Z",
+      "updatedAt": "2026-08-31T18:56:54Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
         "repository": "https://github.com/netdata/netdata",
         "repositorySource": "github",
         "repositorySubfolder": "docs/netdata-ai/mcp",
-        "stargazerCount": 80285,
+        "stargazerCount": 80375,
         "websiteUrl": "https://www.netdata.cloud"
       }
     },
@@ -25915,7 +25928,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:52Z",
+      "updatedAt": "2026-08-31T18:56:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -25943,13 +25956,13 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:51:53Z",
+      "updatedAt": "2026-08-31T18:56:56Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
         "repository": "https://github.com/oleksiijko/pmb",
         "repositorySource": "github",
-        "stargazerCount": 297
+        "stargazerCount": 277
       }
     },
     {
@@ -25971,13 +25984,13 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:55Z",
+      "updatedAt": "2026-08-31T18:56:58Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
         "repository": "https://github.com/openaccountants/openaccountants",
         "repositorySource": "github",
-        "stargazerCount": 342
+        "stargazerCount": 354
       }
     },
     {
@@ -25987,7 +26000,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
       "version": "0.2.0",
-      "updatedAt": "2026-08-25T07:51:56Z",
+      "updatedAt": "2026-08-31T18:56:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -26004,7 +26017,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-08-25T07:51:57Z",
+      "updatedAt": "2026-08-31T18:57:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -26020,13 +26033,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.46.4",
-      "updatedAt": "2026-08-25T07:51:58Z",
+      "updatedAt": "2026-08-31T18:57:01Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
         "repository": "https://github.com/patrickchugh/terravision",
         "repositorySource": "github",
-        "stargazerCount": 1615,
+        "stargazerCount": 1621,
         "websiteUrl": "https://patrickchugh.github.io/terravision/"
       }
     },
@@ -26049,13 +26062,13 @@
         "ucg-fiber"
       ],
       "version": "0.21.1",
-      "updatedAt": "2026-08-25T07:51:59Z",
+      "updatedAt": "2026-08-31T18:57:02Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
         "repository": "https://github.com/pete-builds/mcp-unifi",
         "repositorySource": "github",
-        "stargazerCount": 20,
+        "stargazerCount": 21,
         "websiteUrl": "https://pete-builds.github.io/mcp-unifi/"
       }
     },
@@ -26074,13 +26087,13 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:52:00Z",
+      "updatedAt": "2026-08-31T18:57:04Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
         "repository": "https://github.com/pgEdge/pgedge-postgres-mcp",
         "repositorySource": "github",
-        "stargazerCount": 219
+        "stargazerCount": 221
       }
     },
     {
@@ -26102,7 +26115,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:52:01Z",
+      "updatedAt": "2026-08-31T18:57:05Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -26126,13 +26139,13 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-08-25T07:52:03Z",
+      "updatedAt": "2026-08-31T18:57:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
         "repository": "https://github.com/pubnub/pubnub-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32,
+        "stargazerCount": 33,
         "websiteUrl": "https://www.pubnub.com/networking-mcp-server"
       }
     },
@@ -26143,7 +26156,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:04Z",
+      "updatedAt": "2026-08-31T18:57:08Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -26171,7 +26184,7 @@
         "mcp"
       ],
       "version": "6.0.0",
-      "updatedAt": "2026-08-25T07:52:05Z",
+      "updatedAt": "2026-08-31T18:57:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
@@ -26187,7 +26200,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:52:06Z",
+      "updatedAt": "2026-08-31T18:57:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -26207,13 +26220,13 @@
         "sas-osp"
       ],
       "version": "1.11.1",
-      "updatedAt": "2026-08-25T07:52:07Z",
+      "updatedAt": "2026-08-31T18:57:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
         "repository": "https://github.com/sassoftware/sas-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 52
+        "stargazerCount": 53
       }
     },
     {
@@ -26235,7 +26248,7 @@
         "x402"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:52:09Z",
+      "updatedAt": "2026-08-31T18:57:15Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
@@ -26252,13 +26265,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.1",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:10Z",
+      "updatedAt": "2026-08-31T18:57:16Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
         "repository": "https://github.com/serpapi/serpapi-mcp",
         "repositorySource": "github",
-        "stargazerCount": 166
+        "stargazerCount": 167
       }
     },
     {
@@ -26280,13 +26293,13 @@
         "semantic-scholar"
       ],
       "version": "1.7.3",
-      "updatedAt": "2026-08-25T07:52:11Z",
+      "updatedAt": "2026-08-31T18:57:17Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
         "repository": "https://github.com/smaniches/semantic-scholar-mcp",
         "repositorySource": "github",
-        "stargazerCount": 14
+        "stargazerCount": 15
       }
     },
     {
@@ -26296,7 +26309,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:52:12Z",
+      "updatedAt": "2026-08-31T18:57:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -26313,7 +26326,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-25T07:52:13Z",
+      "updatedAt": "2026-08-31T18:57:19Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -26329,7 +26342,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:52:14Z",
+      "updatedAt": "2026-08-31T18:57:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -26356,13 +26369,13 @@
         "stackql"
       ],
       "version": "0.10.605",
-      "updatedAt": "2026-08-25T07:52:15Z",
+      "updatedAt": "2026-08-31T18:57:22Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
         "repository": "https://github.com/stackql/stackql",
         "repositorySource": "github",
-        "stargazerCount": 874,
+        "stargazerCount": 894,
         "websiteUrl": "https://stackql.io"
       }
     },
@@ -26381,7 +26394,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:16Z",
+      "updatedAt": "2026-08-31T18:57:23Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -26398,13 +26411,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-08-25T07:52:17Z",
+      "updatedAt": "2026-08-31T18:57:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
         "repository": "https://github.com/tavily-ai/tavily-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2352
+        "stargazerCount": 2364
       }
     },
     {
@@ -26418,21 +26431,21 @@
         "claude-code",
         "codex",
         "cursor",
-        "frontend",
         "ios-design",
         "ui-design",
         "design-systems",
         "web-design",
-        "anti-ui-slop"
+        "anti-ui-slop",
+        "ai-agents"
       ],
       "version": "3.0.0",
-      "updatedAt": "2026-08-25T07:52:18Z",
+      "updatedAt": "2026-08-31T18:57:25Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
         "repository": "https://github.com/uizze/uizze",
         "repositorySource": "github",
-        "stargazerCount": 11,
+        "stargazerCount": 15,
         "websiteUrl": "https://uizze.com"
       }
     },
@@ -26440,7 +26453,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.upstash:context7",
       "displayName": "Context7",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.upstash%2Fcontext7/versions/1.0.31",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.upstash%2Fcontext7/versions/4.0.4",
       "description": "Up-to-date code docs for any prompt",
       "tags": [
         "llm",
@@ -26448,14 +26461,15 @@
         "mcp-server",
         "vibe-coding"
       ],
-      "version": "1.0.31",
-      "updatedAt": "2026-08-25T07:52:19Z",
+      "version": "4.0.4",
+      "updatedAt": "2026-08-31T18:57:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
         "repository": "https://github.com/upstash/context7",
         "repositorySource": "github",
-        "stargazerCount": 61180
+        "stargazerCount": 61448,
+        "websiteUrl": "https://context7.com"
       }
     },
     {
@@ -26465,7 +26479,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-08-25T07:52:20Z",
+      "updatedAt": "2026-08-31T18:57:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -26488,13 +26502,13 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-08-25T07:52:22Z",
+      "updatedAt": "2026-08-31T18:57:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
         "repository": "https://github.com/vercel/next-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 811
+        "stargazerCount": 817
       }
     },
     {
@@ -26516,12 +26530,12 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-25T07:52:23Z",
+      "updatedAt": "2026-08-31T18:57:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
         "repositorySource": "github",
-        "stargazerCount": 1232,
+        "stargazerCount": 1226,
         "websiteUrl": "https://docs.vybenetwork.com/docs/mcp"
       }
     },
@@ -26543,13 +26557,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.47",
-      "updatedAt": "2026-08-25T07:52:24Z",
+      "updatedAt": "2026-08-31T18:57:32Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
         "repository": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
         "repositorySource": "github",
-        "stargazerCount": 9389
+        "stargazerCount": 9452
       }
     },
     {
@@ -26562,7 +26576,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-25T07:52:25Z",
+      "updatedAt": "2026-08-31T18:57:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -26575,16 +26589,16 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.zereight:gitlab-mcp",
       "displayName": "Zereight Gitlab",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.52",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.56",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
-      "version": "2.1.52",
-      "updatedAt": "2026-08-25T07:52:26Z",
+      "version": "2.1.56",
+      "updatedAt": "2026-08-31T18:57:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
         "repository": "https://github.com/zereight/gitlab-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1920
+        "stargazerCount": 1934
       }
     },
     {
@@ -26606,13 +26620,13 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-08-25T07:52:28Z",
+      "updatedAt": "2026-08-31T18:57:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
         "repository": "https://github.com/zscaler/zscaler-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 46,
+        "stargazerCount": 50,
         "websiteUrl": "https://github.com/zscaler/zscaler-mcp-server"
       }
     },
@@ -26622,8 +26636,18 @@
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
       "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
+      "tags": [
+        "film-tv",
+        "mcp",
+        "mcp-server",
+        "media-production",
+        "model-context-protocol",
+        "nextjs",
+        "post-production",
+        "typescript"
+      ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:52:29Z",
+      "updatedAt": "2026-08-31T18:57:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -26651,7 +26675,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-25T07:52:30Z",
+      "updatedAt": "2026-08-31T18:57:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -26667,7 +26691,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:52:31Z",
+      "updatedAt": "2026-08-31T18:57:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -26682,7 +26706,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:52:32Z",
+      "updatedAt": "2026-08-31T18:57:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -26703,7 +26727,7 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-08-25T07:52:33Z",
+      "updatedAt": "2026-08-31T18:57:44Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
@@ -26719,7 +26743,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-25T07:52:34Z",
+      "updatedAt": "2026-08-31T18:57:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -26764,7 +26788,7 @@
         "readmeUrl": "https://github.com/makenotion/notion-mcp-server#readme",
         "repository": "https://github.com/makenotion/notion-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4603
+        "stargazerCount": 4617
       }
     },
     {
@@ -26780,7 +26804,7 @@
         "readmeUrl": "https://github.com/microsoft/azure-devops-mcp#readme",
         "repository": "https://github.com/microsoft/azure-devops-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1978
+        "stargazerCount": 1986
       }
     },
     {
@@ -26800,7 +26824,7 @@
         "readmeUrl": "https://github.com/microsoft/clarity-mcp-server#readme",
         "repository": "https://github.com/microsoft/clarity-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 110
+        "stargazerCount": 112
       }
     },
     {
@@ -26815,7 +26839,7 @@
         "readmeUrl": "https://github.com/microsoft/devbox-mcp-server#readme",
         "repository": "https://github.com/microsoft/devbox-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 12
+        "stargazerCount": 13
       }
     },
     {
@@ -26831,7 +26855,7 @@
         "readmeUrl": "https://github.com/microsoft/fabric-rti-mcp#readme",
         "repository": "https://github.com/microsoft/fabric-rti-mcp",
         "repositorySource": "github",
-        "stargazerCount": 129
+        "stargazerCount": 130
       }
     },
     {
@@ -26856,7 +26880,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 176100
+        "stargazerCount": 177373
       }
     },
     {
@@ -26876,7 +26900,7 @@
         "readmeUrl": "https://github.com/microsoft/playwright-mcp#readme",
         "repository": "https://github.com/microsoft/playwright-mcp",
         "repositorySource": "github",
-        "stargazerCount": 36442
+        "stargazerCount": 36663
       }
     },
     {
@@ -26904,7 +26928,7 @@
         "readmeUrl": "https://github.com/microsoftdocs/mcp#readme",
         "repository": "https://github.com/microsoftdocs/mcp",
         "repositorySource": "github",
-        "stargazerCount": 1858
+        "stargazerCount": 1866
       }
     },
     {
@@ -26920,7 +26944,7 @@
         "readmeUrl": "https://github.com/neondatabase/mcp-server-neon#readme",
         "repository": "https://github.com/neondatabase/mcp-server-neon",
         "repositorySource": "github",
-        "stargazerCount": 624
+        "stargazerCount": 625
       }
     },
     {
@@ -26963,7 +26987,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-08-25T07:52:35Z",
+      "updatedAt": "2026-08-31T18:57:46Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -26992,7 +27016,7 @@
         "typescript"
       ],
       "version": "2.3.1",
-      "updatedAt": "2026-08-25T07:52:37Z",
+      "updatedAt": "2026-08-31T18:57:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -27027,14 +27051,14 @@
         "readmeUrl": "https://github.com/oraios/serena#readme",
         "repository": "https://github.com/oraios/serena",
         "repositorySource": "github",
-        "stargazerCount": 28470
+        "stargazerCount": 28686
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:org.sylin:ghostlight",
       "displayName": "Sylin Ghostlight",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/0.8.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/1.3.1",
       "description": "Visible local browser automation in signed-in Chromium, with optional policy and audit.",
       "tags": [
         "access-control",
@@ -27048,8 +27072,8 @@
         "model-context-protocol",
         "rust"
       ],
-      "version": "0.8.0",
-      "updatedAt": "2026-08-25T07:52:38Z",
+      "version": "1.3.1",
+      "updatedAt": "2026-08-31T18:57:49Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -27078,7 +27102,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:39Z",
+      "updatedAt": "2026-08-31T18:57:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -27127,7 +27151,7 @@
         "readmeUrl": "https://github.com/sunriseapps/imagesorcery-mcp#readme",
         "repository": "https://github.com/sunriseapps/imagesorcery-mcp",
         "repositorySource": "github",
-        "stargazerCount": 326
+        "stargazerCount": 329
       }
     },
     {
@@ -27137,7 +27161,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:40Z",
+      "updatedAt": "2026-08-31T18:57:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",
@@ -27170,7 +27194,7 @@
         "readmeUrl": "https://github.com/zapier/zapier-mcp#readme",
         "repository": "https://github.com/zapier/zapier-mcp",
         "repositorySource": "github",
-        "stargazerCount": 388
+        "stargazerCount": 396
       }
     }
   ]

--- a/catalog/perforce/perforce-agentic-gateway.json
+++ b/catalog/perforce/perforce-agentic-gateway.json
@@ -1,0 +1,8 @@
+{
+  "identifier": "urn:ai:registry.modelcontextprotocol.io:io.github.perforce:perforce-agentic-gateway",
+  "displayName": "Perforce Agentic Gateway",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.perforce%2Fperforce-agentic-gateway/versions/2026.5",
+  "description": "Local MCP gateway that proxies AI clients to many MCP servers with a token-efficient code mode.",
+  "version": "2026.5"
+}


### PR DESCRIPTION
## Summary

Adds a contributor-owned catalog entry for [Perforce Agentic Gateway](https://github.com/perforce/perforce-agentic-gateway). The gateway is already published in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers/io.github.perforce%2Fperforce-agentic-gateway/versions/2026.5), but it is not currently present in GitHub's public MCP catalog, so an explicit entry is needed for Agent Finder discovery.

## Validation

- `python3 -m json.tool catalog/perforce/perforce-agentic-gateway.json`
- `python3 scripts/generate_ai_catalog.py`
- `python3 scripts/generate_ai_catalog.py --check`
- `python3 -m unittest discover -s tests`