### PR TITLE
Add Living Stack skill

### DIFF
--- a/catalog/equinoxaifinance-rgb/living-stack.json
+++ b/catalog/equinoxaifinance-rgb/living-stack.json
@@ -1,0 +1,19 @@
+{
+  "identifier": "urn:ai:github.com:equinoxaifinance-rgb:living-stack-mcp:living-stack",
+  "displayName": "Living Stack",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/equinoxaifinance-rgb/living-stack-mcp/blob/v0.3.4-beta.1/skills/living-stack/SKILL.md",
+  "description": "Guides agents to use the free Living Stack Community MCP server for scoped authorization, evidence-bound claims, budget gates, recovery, and signed traces.",
+  "version": "0.3.4-beta.1",
+  "tags": [
+    "agent-governance",
+    "authorization",
+    "evidence",
+    "mcp",
+    "recovery"
+  ],
+  "metadata": {
+    "sourceSet": "equinoxaifinance-rgb/living-stack-mcp",
+    "repoPath": "skills/living-stack/SKILL.md"
+  }
+}


### PR DESCRIPTION
Adds the versioned Living Stack Community skill to the Agent Finder catalog.

The skill guides agents through the free Living Stack MCP server’s bounded authorization, evidence-bound claim checks, budget gates, checkpoints, and signed trace workflow.

- Source: https://github.com/equinoxaifinance-rgb/living-stack-mcp
- Immutable skill: https://github.com/equinoxaifinance-rgb/living-stack-mcp/blob/v0.3.4-beta.1/skills/living-stack/SKILL.md
- License: Apache-2.0
- Product tier: Community (free)

Validated against upstream commit `4de5bca206b72932f5d6b4f378680324885a10d7` with `python -m json.tool`, `generate_ai_catalog.py`, and `generate_ai_catalog.py --check`.