### PR TITLE
Add SCVD General Store (two skills, one MCP server)

### DIFF
--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -22466,7 +22466,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:38:54Z",
+      "updatedAt": "2026-09-11T18:44:57Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -22481,7 +22481,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.bowmark%2Fbowmark/versions/8.113.1",
       "description": "Do things on live websites: prices, availability, quotes, bookings, anything behind a form or login.",
       "version": "8.113.1",
-      "updatedAt": "2026-09-11T17:38:56Z",
+      "updatedAt": "2026-09-11T18:44:58Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/bowmark-ai/skill#readme",
@@ -22497,7 +22497,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.certscore%2Fmcp-light/versions/0.2.20",
       "description": "Free website privacy scanner for pre-consent cookies, trackers, consent, policy, and HTTPS/TLS.",
       "version": "0.2.20",
-      "updatedAt": "2026-09-11T17:39:11Z",
+      "updatedAt": "2026-09-11T18:45:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ergoveritas1-alt/certscore.ai/tree/HEAD/packages/certscore-mcp",
@@ -22514,7 +22514,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-09-11T17:39:12Z",
+      "updatedAt": "2026-09-11T18:45:14Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22539,7 +22539,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-09-11T17:39:13Z",
+      "updatedAt": "2026-09-11T18:45:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22554,7 +22554,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-09-11T17:39:14Z",
+      "updatedAt": "2026-09-11T18:45:17Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22578,7 +22578,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-09-11T17:39:16Z",
+      "updatedAt": "2026-09-11T18:45:18Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -22605,7 +22605,7 @@
         "claude-code"
       ],
       "version": "1.19.0",
-      "updatedAt": "2026-09-11T17:39:18Z",
+      "updatedAt": "2026-09-11T18:45:20Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -22629,7 +22629,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.1",
-      "updatedAt": "2026-09-11T17:39:19Z",
+      "updatedAt": "2026-09-11T18:45:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -22657,7 +22657,7 @@
         "accounting"
       ],
       "version": "1.10.2",
-      "updatedAt": "2026-09-11T17:39:21Z",
+      "updatedAt": "2026-09-11T18:45:23Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/RoboFinSystems/robosystems#readme",
@@ -22686,7 +22686,7 @@
         "x402"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-09-11T17:39:22Z",
+      "updatedAt": "2026-09-11T18:45:24Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -22739,7 +22739,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-09-11T17:39:23Z",
+      "updatedAt": "2026-09-11T18:45:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22765,12 +22765,12 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T17:39:24Z",
+      "updatedAt": "2026-09-11T18:45:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
         "repositorySource": "github",
-        "stargazerCount": 26,
+        "stargazerCount": 27,
         "websiteUrl": "https://mcp.desktopcommander.app"
       }
     },
@@ -22789,7 +22789,7 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:25Z",
+      "updatedAt": "2026-09-11T18:45:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
@@ -22805,7 +22805,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:26Z",
+      "updatedAt": "2026-09-11T18:45:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -22832,7 +22832,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T17:39:28Z",
+      "updatedAt": "2026-09-11T18:45:31Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -22928,7 +22928,7 @@
         "mcp"
       ],
       "version": "2.12.11",
-      "updatedAt": "2026-09-11T17:39:29Z",
+      "updatedAt": "2026-09-11T18:45:33Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22945,7 +22945,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:30Z",
+      "updatedAt": "2026-09-11T18:45:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22973,7 +22973,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-09-11T17:39:31Z",
+      "updatedAt": "2026-09-11T18:45:36Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -23036,13 +23036,13 @@
         "mcp-server"
       ],
       "version": "0.15.7",
-      "updatedAt": "2026-09-11T17:39:33Z",
+      "updatedAt": "2026-09-11T18:45:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 6773
+        "stargazerCount": 6780
       }
     },
     {
@@ -23064,7 +23064,7 @@
         "cursor"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-09-11T17:39:35Z",
+      "updatedAt": "2026-09-11T18:45:40Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
@@ -23081,7 +23081,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-09-11T17:39:36Z",
+      "updatedAt": "2026-09-11T18:45:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -23096,7 +23096,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:38Z",
+      "updatedAt": "2026-09-11T18:45:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23112,7 +23112,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:39Z",
+      "updatedAt": "2026-09-11T18:45:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23128,7 +23128,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:40Z",
+      "updatedAt": "2026-09-11T18:45:45Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23144,7 +23144,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:41Z",
+      "updatedAt": "2026-09-11T18:45:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23160,7 +23160,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:42Z",
+      "updatedAt": "2026-09-11T18:45:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23176,7 +23176,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:43Z",
+      "updatedAt": "2026-09-11T18:45:48Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23192,7 +23192,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Felr/versions/1.0.0",
       "description": "Provides access to Avalara E-Invoicing and Live Reporting APIs for document statuses and compliance",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T17:39:44Z",
+      "updatedAt": "2026-09-11T18:45:49Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23208,7 +23208,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:45Z",
+      "updatedAt": "2026-09-11T18:45:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23224,7 +23224,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-09-11T17:39:46Z",
+      "updatedAt": "2026-09-11T18:45:51Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23238,7 +23238,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-09-11T17:39:47Z",
+      "updatedAt": "2026-09-11T18:45:52Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -23262,7 +23262,7 @@
         "mcp"
       ],
       "version": "0.6.1",
-      "updatedAt": "2026-09-11T17:39:48Z",
+      "updatedAt": "2026-09-11T18:45:53Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/celigo/ai#readme",
@@ -23289,7 +23289,7 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-09-11T17:39:49Z",
+      "updatedAt": "2026-09-11T18:45:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
@@ -23317,7 +23317,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T17:39:51Z",
+      "updatedAt": "2026-09-11T18:45:57Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23334,7 +23334,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-09-11T17:39:52Z",
+      "updatedAt": "2026-09-11T18:45:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23348,7 +23348,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T17:39:53Z",
+      "updatedAt": "2026-09-11T18:45:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
@@ -23375,7 +23375,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-09-11T17:39:54Z",
+      "updatedAt": "2026-09-11T18:46:00Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -23391,7 +23391,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T17:39:55Z",
+      "updatedAt": "2026-09-11T18:46:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -23406,7 +23406,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T17:39:56Z",
+      "updatedAt": "2026-09-11T18:46:03Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -23431,7 +23431,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:39:57Z",
+      "updatedAt": "2026-09-11T18:46:04Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -23457,7 +23457,7 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-09-11T17:39:58Z",
+      "updatedAt": "2026-09-11T18:46:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
@@ -23473,7 +23473,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-09-11T17:39:59Z",
+      "updatedAt": "2026-09-11T18:46:06Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -23500,7 +23500,7 @@
         "technical-drawing"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T17:40:01Z",
+      "updatedAt": "2026-09-11T18:46:08Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -23516,7 +23516,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.industry-lens%2Fmcp-public/versions/0.2.0",
       "description": "B2B SaaS competitor pricing changes, strategic moves, market landscapes, reports and comparisons.",
       "version": "0.2.0",
-      "updatedAt": "2026-09-11T17:40:02Z",
+      "updatedAt": "2026-09-11T18:46:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/IndustryLensOp/industrylens-mcp-docs#readme",
         "repository": "https://github.com/IndustryLensOp/industrylens-mcp-docs",
@@ -23539,7 +23539,7 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-09-11T17:40:04Z",
+      "updatedAt": "2026-09-11T18:46:10Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -23559,7 +23559,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T17:40:05Z",
+      "updatedAt": "2026-09-11T18:46:12Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23586,7 +23586,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:40:06Z",
+      "updatedAt": "2026-09-11T18:46:13Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -23612,7 +23612,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T17:40:07Z",
+      "updatedAt": "2026-09-11T18:46:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
@@ -23637,7 +23637,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-09-11T17:40:09Z",
+      "updatedAt": "2026-09-11T18:46:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23653,7 +23653,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.42",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
       "version": "3.0.0-beta.42",
-      "updatedAt": "2026-09-11T17:40:10Z",
+      "updatedAt": "2026-09-11T18:46:18Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
@@ -23671,7 +23671,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.4.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
       "version": "1.4.0",
-      "updatedAt": "2026-09-11T17:40:12Z",
+      "updatedAt": "2026-09-11T18:46:20Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
@@ -23689,7 +23689,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-09-11T17:40:13Z",
+      "updatedAt": "2026-09-11T18:46:21Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
@@ -23706,7 +23706,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:40:14Z",
+      "updatedAt": "2026-09-11T18:46:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23725,7 +23725,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T17:40:16Z",
+      "updatedAt": "2026-09-11T18:46:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -23747,7 +23747,7 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-09-11T17:40:17Z",
+      "updatedAt": "2026-09-11T18:46:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
@@ -23770,7 +23770,7 @@
         "sports-betting"
       ],
       "version": "1.4.5",
-      "updatedAt": "2026-09-11T17:40:18Z",
+      "updatedAt": "2026-09-11T18:46:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/jessejohnsohn/negativeev-mcp#readme",
         "repository": "https://github.com/jessejohnsohn/negativeev-mcp",
@@ -23785,7 +23785,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.nitrosend%2Fnitrosend/versions/0.8.2",
       "description": "AI-native email marketing. Campaigns, automations, transactional, contacts, and analytics.",
       "version": "0.8.2",
-      "updatedAt": "2026-09-11T17:40:19Z",
+      "updatedAt": "2026-09-11T18:46:28Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/nitrosend/mcp#readme",
@@ -23802,7 +23802,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T17:40:20Z",
+      "updatedAt": "2026-09-11T18:46:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23829,7 +23829,7 @@
         "copilot"
       ],
       "version": "2.12.3",
-      "updatedAt": "2026-09-11T17:40:21Z",
+      "updatedAt": "2026-09-11T18:46:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
@@ -23846,7 +23846,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T17:40:23Z",
+      "updatedAt": "2026-09-11T18:46:32Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23875,7 +23875,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T17:40:24Z",
+      "updatedAt": "2026-09-11T18:46:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23900,7 +23900,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T17:40:25Z",
+      "updatedAt": "2026-09-11T18:46:35Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23926,7 +23926,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T17:40:27Z",
+      "updatedAt": "2026-09-11T18:46:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23942,7 +23942,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.52.10",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.52.10",
-      "updatedAt": "2026-09-11T17:40:28Z",
+      "updatedAt": "2026-09-11T18:46:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23969,7 +23969,7 @@
         "static-site"
       ],
       "version": "1.10.2",
-      "updatedAt": "2026-09-11T17:40:29Z",
+      "updatedAt": "2026-09-11T18:46:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
@@ -23998,7 +23998,7 @@
         "swagger"
       ],
       "version": "0.40.0",
-      "updatedAt": "2026-09-11T17:40:31Z",
+      "updatedAt": "2026-09-11T18:46:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -24026,7 +24026,7 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-09-11T17:40:33Z",
+      "updatedAt": "2026-09-11T18:46:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -24042,7 +24042,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T17:40:34Z",
+      "updatedAt": "2026-09-11T18:46:45Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -24060,7 +24060,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-09-11T17:40:35Z",
+      "updatedAt": "2026-09-11T18:46:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -24077,7 +24077,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T17:40:36Z",
+      "updatedAt": "2026-09-11T18:46:47Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
@@ -24093,7 +24093,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-09-11T17:40:37Z",
+      "updatedAt": "2026-09-11T18:46:48Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
@@ -24118,7 +24118,7 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-09-11T17:40:39Z",
+      "updatedAt": "2026-09-11T18:46:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
@@ -24134,7 +24134,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.12.0",
       "description": "MCP server for interacting with the Supabase platform",
       "version": "0.12.0",
-      "updatedAt": "2026-09-11T17:40:40Z",
+      "updatedAt": "2026-09-11T18:46:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
@@ -24152,7 +24152,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.2.0",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.2.0",
-      "updatedAt": "2026-09-11T17:40:41Z",
+      "updatedAt": "2026-09-11T18:46:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -24169,7 +24169,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-09-11T17:40:42Z",
+      "updatedAt": "2026-09-11T18:46:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
@@ -24345,7 +24345,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 14136
+        "stargazerCount": 14137
       }
     },
     {
@@ -24567,7 +24567,7 @@
         "readmeUrl": "https://github.com/firecrawl/firecrawl-mcp-server#readme",
         "repository": "https://github.com/firecrawl/firecrawl-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 7435
+        "stargazerCount": 7436
       }
     },
     {
@@ -25531,7 +25531,7 @@
         "ed25519"
       ],
       "version": "2.4.0",
-      "updatedAt": "2026-09-11T16:35:57Z",
+      "updatedAt": "2026-09-11T17:41:50Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -25548,7 +25548,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.1",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
       "version": "1.30.1",
-      "updatedAt": "2026-09-11T16:35:58Z",
+      "updatedAt": "2026-09-11T17:41:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -25571,7 +25571,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-09-11T16:35:59Z",
+      "updatedAt": "2026-09-11T17:41:53Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -25599,7 +25599,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-09-11T16:36:00Z",
+      "updatedAt": "2026-09-11T17:41:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -25627,7 +25627,7 @@
         "ai-agents"
       ],
       "version": "0.21.5",
-      "updatedAt": "2026-09-11T16:36:02Z",
+      "updatedAt": "2026-09-11T17:41:56Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -25656,7 +25656,7 @@
         "cursor"
       ],
       "version": "1.5.1",
-      "updatedAt": "2026-09-11T16:36:03Z",
+      "updatedAt": "2026-09-11T17:41:58Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/alimbenhelal-pro/ALM-XPP-MCP#readme",
@@ -25683,7 +25683,7 @@
         "mcp-server"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-09-11T16:36:05Z",
+      "updatedAt": "2026-09-11T17:41:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anilloutombam/mcp-failure-lab#readme",
@@ -25706,7 +25706,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:06Z",
+      "updatedAt": "2026-09-11T17:42:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25731,7 +25731,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:07Z",
+      "updatedAt": "2026-09-11T17:42:01Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25756,7 +25756,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:08Z",
+      "updatedAt": "2026-09-11T17:42:02Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25781,7 +25781,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:09Z",
+      "updatedAt": "2026-09-11T17:42:04Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25806,7 +25806,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:10Z",
+      "updatedAt": "2026-09-11T17:42:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25831,7 +25831,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:12Z",
+      "updatedAt": "2026-09-11T17:42:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25856,7 +25856,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:13Z",
+      "updatedAt": "2026-09-11T17:42:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25881,7 +25881,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T16:36:14Z",
+      "updatedAt": "2026-09-11T17:42:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25910,7 +25910,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-09-11T16:36:15Z",
+      "updatedAt": "2026-09-11T17:42:10Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -25927,7 +25927,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-09-11T16:36:17Z",
+      "updatedAt": "2026-09-11T17:42:11Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -25956,7 +25956,7 @@
         "knowlege-graph"
       ],
       "version": "0.23.2",
-      "updatedAt": "2026-09-11T16:36:18Z",
+      "updatedAt": "2026-09-11T17:42:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
@@ -25984,13 +25984,13 @@
         "data-extraction"
       ],
       "version": "2.11.2",
-      "updatedAt": "2026-09-11T16:36:19Z",
+      "updatedAt": "2026-09-11T17:42:14Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
         "repository": "https://github.com/brightdata/brightdata-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2635
+        "stargazerCount": 2636
       }
     },
     {
@@ -26012,7 +26012,7 @@
         "sqlserver"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-09-11T16:36:21Z",
+      "updatedAt": "2026-09-11T17:42:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
@@ -26040,7 +26040,7 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:36:22Z",
+      "updatedAt": "2026-09-11T17:42:17Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
@@ -26056,7 +26056,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.carterchencc%2Fnomas/versions/1.3.2",
       "description": "Parsed SEC events by CIK/CUSIP: 8-K items, Form 144, Form D, FTD. Not EDGAR HTML.",
       "version": "1.3.2",
-      "updatedAt": "2026-09-11T16:36:23Z",
+      "updatedAt": "2026-09-11T17:42:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/carterchencc/nomas_mcp#readme",
         "repository": "https://github.com/carterchencc/nomas_mcp",
@@ -26083,7 +26083,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T16:36:24Z",
+      "updatedAt": "2026-09-11T17:42:19Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -26112,7 +26112,7 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-09-11T16:36:26Z",
+      "updatedAt": "2026-09-11T17:42:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
@@ -26141,7 +26141,7 @@
         "context"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-09-11T16:36:27Z",
+      "updatedAt": "2026-09-11T17:42:21Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
@@ -26158,7 +26158,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-09-11T16:36:28Z",
+      "updatedAt": "2026-09-11T17:42:23Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -26186,7 +26186,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.4",
-      "updatedAt": "2026-09-11T16:36:29Z",
+      "updatedAt": "2026-09-11T17:42:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -26210,7 +26210,7 @@
         "observability"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T16:36:31Z",
+      "updatedAt": "2026-09-11T17:42:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -26226,7 +26226,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-09-11T16:36:32Z",
+      "updatedAt": "2026-09-11T17:42:26Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
@@ -26242,7 +26242,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-09-11T16:36:33Z",
+      "updatedAt": "2026-09-11T17:42:27Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -26262,7 +26262,7 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-09-11T16:36:34Z",
+      "updatedAt": "2026-09-11T17:42:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
@@ -26284,13 +26284,13 @@
         "mcp-server"
       ],
       "version": "1.12.1",
-      "updatedAt": "2026-09-11T16:36:36Z",
+      "updatedAt": "2026-09-11T17:42:30Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32874
+        "stargazerCount": 32876
       }
     },
     {
@@ -26305,7 +26305,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T16:36:38Z",
+      "updatedAt": "2026-09-11T17:42:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -26321,7 +26321,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:36:39Z",
+      "updatedAt": "2026-09-11T17:42:34Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
@@ -26349,7 +26349,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T16:36:40Z",
+      "updatedAt": "2026-09-11T17:42:35Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -26374,7 +26374,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.59.0",
-      "updatedAt": "2026-09-11T16:36:41Z",
+      "updatedAt": "2026-09-11T17:42:36Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
@@ -26402,7 +26402,7 @@
         "privacy"
       ],
       "version": "2.2.0",
-      "updatedAt": "2026-09-11T16:36:44Z",
+      "updatedAt": "2026-09-11T17:42:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
@@ -26430,7 +26430,7 @@
         "rag"
       ],
       "version": "4.16.0",
-      "updatedAt": "2026-09-11T16:36:46Z",
+      "updatedAt": "2026-09-11T17:42:42Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
@@ -26457,7 +26457,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T16:36:49Z",
+      "updatedAt": "2026-09-11T17:42:44Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -26472,7 +26472,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.1",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.1",
-      "updatedAt": "2026-09-11T16:36:50Z",
+      "updatedAt": "2026-09-11T17:42:45Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -26488,7 +26488,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-09-11T16:36:51Z",
+      "updatedAt": "2026-09-11T17:42:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
@@ -26504,7 +26504,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-09-11T16:36:53Z",
+      "updatedAt": "2026-09-11T17:42:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
@@ -26520,7 +26520,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:36:54Z",
+      "updatedAt": "2026-09-11T17:42:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
@@ -26541,7 +26541,7 @@
         "mcp-server"
       ],
       "version": "1.0.2026090704",
-      "updatedAt": "2026-09-11T16:36:55Z",
+      "updatedAt": "2026-09-11T17:42:51Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -26558,7 +26558,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T16:36:59Z",
+      "updatedAt": "2026-09-11T17:42:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
@@ -26586,7 +26586,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.7",
-      "updatedAt": "2026-09-11T16:37:00Z",
+      "updatedAt": "2026-09-11T17:42:56Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -26615,7 +26615,7 @@
         "mcp"
       ],
       "version": "0.8.11",
-      "updatedAt": "2026-09-11T16:37:02Z",
+      "updatedAt": "2026-09-11T17:42:58Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -26639,7 +26639,7 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-09-11T16:37:03Z",
+      "updatedAt": "2026-09-11T17:42:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
@@ -26667,7 +26667,7 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-09-11T16:37:04Z",
+      "updatedAt": "2026-09-11T17:43:01Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
@@ -26685,7 +26685,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:37:06Z",
+      "updatedAt": "2026-09-11T17:43:02Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -26713,7 +26713,7 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T16:37:07Z",
+      "updatedAt": "2026-09-11T17:43:03Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
@@ -26741,7 +26741,7 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:37:08Z",
+      "updatedAt": "2026-09-11T17:43:05Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
@@ -26769,7 +26769,7 @@
         "section-301"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T16:37:09Z",
+      "updatedAt": "2026-09-11T17:43:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/opsloft/tariff-resolver#readme",
@@ -26798,7 +26798,7 @@
         "video-editing"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-09-11T16:37:11Z",
+      "updatedAt": "2026-09-11T17:43:07Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -26815,7 +26815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-09-11T16:37:12Z",
+      "updatedAt": "2026-09-11T17:43:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -26831,13 +26831,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.47.0",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.47.0",
-      "updatedAt": "2026-09-11T16:37:13Z",
+      "updatedAt": "2026-09-11T17:43:09Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
         "repository": "https://github.com/patrickchugh/terravision",
         "repositorySource": "github",
-        "stargazerCount": 1629,
+        "stargazerCount": 1630,
         "websiteUrl": "https://patrickchugh.github.io/terravision/"
       }
     },
@@ -26860,7 +26860,7 @@
         "ucg-fiber"
       ],
       "version": "0.21.2",
-      "updatedAt": "2026-09-11T16:37:14Z",
+      "updatedAt": "2026-09-11T17:43:11Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
@@ -26885,7 +26885,7 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T16:37:16Z",
+      "updatedAt": "2026-09-11T17:43:12Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
@@ -26913,7 +26913,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T16:37:17Z",
+      "updatedAt": "2026-09-11T17:43:13Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -26937,7 +26937,7 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-09-11T16:37:18Z",
+      "updatedAt": "2026-09-11T17:43:15Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
@@ -26954,7 +26954,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T16:37:19Z",
+      "updatedAt": "2026-09-11T17:43:16Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -26982,7 +26982,7 @@
         "mcp"
       ],
       "version": "6.1.0",
-      "updatedAt": "2026-09-11T16:37:21Z",
+      "updatedAt": "2026-09-11T17:43:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
@@ -26998,7 +26998,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T16:37:23Z",
+      "updatedAt": "2026-09-11T17:43:20Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -27018,7 +27018,7 @@
         "sas-osp"
       ],
       "version": "1.14.2",
-      "updatedAt": "2026-09-11T16:37:24Z",
+      "updatedAt": "2026-09-11T17:43:21Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
@@ -27046,7 +27046,7 @@
         "tiktok"
       ],
       "version": "0.14.1",
-      "updatedAt": "2026-09-11T16:37:25Z",
+      "updatedAt": "2026-09-11T17:43:22Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/scavio-ai/scavio-mcp#readme",
@@ -27062,7 +27062,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.3",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T16:37:27Z",
+      "updatedAt": "2026-09-11T17:43:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
@@ -27087,7 +27087,7 @@
         "typescript"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T16:37:28Z",
+      "updatedAt": "2026-09-11T17:43:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shariqriazz/google-ai-search-mcp#readme",
@@ -27115,7 +27115,7 @@
         "semantic-scholar"
       ],
       "version": "1.7.4",
-      "updatedAt": "2026-09-11T16:37:29Z",
+      "updatedAt": "2026-09-11T17:43:26Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
@@ -27143,7 +27143,7 @@
         "drug-repurposing"
       ],
       "version": "1.3.6",
-      "updatedAt": "2026-09-11T16:37:31Z",
+      "updatedAt": "2026-09-11T17:43:27Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/uniprot-mcp#readme",
@@ -27159,7 +27159,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T16:37:32Z",
+      "updatedAt": "2026-09-11T17:43:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -27176,7 +27176,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-09-11T16:37:33Z",
+      "updatedAt": "2026-09-11T17:43:30Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -27192,7 +27192,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T16:37:34Z",
+      "updatedAt": "2026-09-11T17:43:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -27219,7 +27219,7 @@
         "stackql"
       ],
       "version": "0.11.669",
-      "updatedAt": "2026-09-11T16:37:36Z",
+      "updatedAt": "2026-09-11T17:43:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
@@ -27244,7 +27244,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T16:37:37Z",
+      "updatedAt": "2026-09-11T17:43:34Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -27261,7 +27261,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-09-11T16:37:38Z",
+      "updatedAt": "2026-09-11T17:43:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
@@ -27289,7 +27289,7 @@
         "ai-agents"
       ],
       "version": "3.0.2",
-      "updatedAt": "2026-09-11T16:37:39Z",
+      "updatedAt": "2026-09-11T17:43:36Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
@@ -27312,7 +27312,7 @@
         "vibe-coding"
       ],
       "version": "4.1.0",
-      "updatedAt": "2026-09-11T16:37:40Z",
+      "updatedAt": "2026-09-11T17:43:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
@@ -27329,7 +27329,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-09-11T16:37:42Z",
+      "updatedAt": "2026-09-11T17:43:38Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -27352,7 +27352,7 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-09-11T16:37:43Z",
+      "updatedAt": "2026-09-11T17:43:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
@@ -27380,7 +27380,7 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-09-11T16:37:44Z",
+      "updatedAt": "2026-09-11T17:43:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
@@ -27407,13 +27407,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.50",
-      "updatedAt": "2026-09-11T16:37:45Z",
+      "updatedAt": "2026-09-11T17:43:42Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
         "repository": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
         "repositorySource": "github",
-        "stargazerCount": 9542
+        "stargazerCount": 9545
       }
     },
     {
@@ -27426,7 +27426,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-09-11T16:37:47Z",
+      "updatedAt": "2026-09-11T17:43:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -27442,7 +27442,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.61",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
       "version": "2.1.61",
-      "updatedAt": "2026-09-11T16:37:48Z",
+      "updatedAt": "2026-09-11T17:43:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
@@ -27470,7 +27470,7 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-09-11T16:37:50Z",
+      "updatedAt": "2026-09-11T17:43:47Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
@@ -27497,7 +27497,7 @@
         "typescript"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T16:37:52Z",
+      "updatedAt": "2026-09-11T17:43:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -27525,7 +27525,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-09-11T16:37:53Z",
+      "updatedAt": "2026-09-11T17:43:50Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -27541,7 +27541,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T16:37:54Z",
+      "updatedAt": "2026-09-11T17:43:51Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -27556,7 +27556,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T16:37:55Z",
+      "updatedAt": "2026-09-11T17:43:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -27577,7 +27577,7 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-09-11T16:37:56Z",
+      "updatedAt": "2026-09-11T17:43:54Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
@@ -27593,7 +27593,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-09-11T16:37:57Z",
+      "updatedAt": "2026-09-11T17:43:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -27656,7 +27656,7 @@
         "speedtest"
       ],
       "version": "1.1.3",
-      "updatedAt": "2026-09-11T16:37:59Z",
+      "updatedAt": "2026-09-11T17:43:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/SpeedOfMe/speedofme-mcp#readme",
         "repository": "https://github.com/SpeedOfMe/speedofme-mcp",
@@ -27754,7 +27754,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 182637
+        "stargazerCount": 182645
       }
     },
     {
@@ -27774,7 +27774,7 @@
         "readmeUrl": "https://github.com/microsoft/playwright-mcp#readme",
         "repository": "https://github.com/microsoft/playwright-mcp",
         "repositorySource": "github",
-        "stargazerCount": 37014
+        "stargazerCount": 37015
       }
     },
     {
@@ -27818,7 +27818,7 @@
         "readmeUrl": "https://github.com/neondatabase/mcp-server-neon#readme",
         "repository": "https://github.com/neondatabase/mcp-server-neon",
         "repositorySource": "github",
-        "stargazerCount": 640
+        "stargazerCount": 641
       }
     },
     {
@@ -27861,7 +27861,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-09-11T16:38:00Z",
+      "updatedAt": "2026-09-11T17:43:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -27890,7 +27890,7 @@
         "typescript"
       ],
       "version": "3.0.2",
-      "updatedAt": "2026-09-11T16:38:01Z",
+      "updatedAt": "2026-09-11T17:43:58Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -27947,7 +27947,7 @@
         "rust"
       ],
       "version": "1.3.5",
-      "updatedAt": "2026-09-11T16:38:03Z",
+      "updatedAt": "2026-09-11T17:44:00Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -27976,7 +27976,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T16:38:04Z",
+      "updatedAt": "2026-09-11T17:44:01Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -28035,7 +28035,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T16:38:05Z",
+      "updatedAt": "2026-09-11T17:44:02Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -20544,6 +20544,74 @@
       "type": "application/ai-skill"
     },
     {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:store.scvd:general-store",
+      "displayName": "SCVD General Store",
+      "mediaType": "application/mcp-server+json",
+      "url": "https://registry.modelcontextprotocol.io/v0/servers/store.scvd%2Fgeneral-store/versions/0.2.3",
+      "description": "Evidence observatory for agentic commerce: x402 preflight, receipt checks, settlement attestations.",
+      "tags": [
+        "x402",
+        "agentic-commerce",
+        "conformance",
+        "verification",
+        "signed-artifacts",
+        "attestation",
+        "mcp",
+        "usdc",
+        "payments"
+      ],
+      "version": "0.2.3",
+      "metadata": {
+        "repository": "https://github.com/seancrecord/scvd-general-store-repo",
+        "repositorySource": "github",
+        "websiteUrl": "https://scvd.store",
+        "readmeUrl": "https://github.com/seancrecord/scvd-general-store-repo#readme"
+      },
+      "type": "application/mcp-server+json"
+    },
+    {
+      "identifier": "urn:air:github.com:seancrecord:scvd-general-store-repo:scvd-general-store",
+      "displayName": "SCVD General Store",
+      "mediaType": "application/ai-skill",
+      "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/skills/scvd-general-store/SKILL.md",
+      "description": "Evidence observatory for agentic commerce: free x402 preflight of any endpoint, free conformance checks of any issuer's signed offers and receipts, and a live practice counter from $0.001. Every artifact is ed25519-signed and verifies free.",
+      "tags": [
+        "x402",
+        "agentic-commerce",
+        "conformance",
+        "verification",
+        "signed-artifacts",
+        "usdc",
+        "payments",
+        "skill"
+      ],
+      "metadata": {
+        "sourceSet": "seancrecord/scvd-general-store-repo",
+        "repoPath": "skills/scvd-general-store/SKILL.md"
+      },
+      "type": "application/ai-skill"
+    },
+    {
+      "identifier": "urn:air:github.com:seancrecord:scvd-general-store-repo:x402-before-you-pay",
+      "displayName": "x402: Before You Pay",
+      "mediaType": "application/ai-skill",
+      "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/examples/claude-code/SKILL.md",
+      "description": "Before an agent pays an x402 endpoint, read its 402 terms and run scvd.store's free preflight and dry run over the same bytes; decide pay, do_not_pay or cannot_tell with every reason named.",
+      "tags": [
+        "x402",
+        "payments",
+        "preflight",
+        "agentic-commerce",
+        "verification",
+        "skill"
+      ],
+      "metadata": {
+        "sourceSet": "seancrecord/scvd-general-store-repo",
+        "repoPath": "examples/claude-code/SKILL.md"
+      },
+      "type": "application/ai-skill"
+    },
+    {
       "identifier": "urn:air:github.com:shader-slang:slang-skills:slang-analyze-coverage",
       "displayName": "Slang Analyze Coverage",
       "mediaType": "application/ai-skill",
@@ -22398,12 +22466,45 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:00Z",
+      "updatedAt": "2026-09-11T14:15:01Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
         "repositorySource": "github",
         "websiteUrl": "https://bittlebits.ai/docs/mcp"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:ai.bowmark:bowmark",
+      "displayName": "Bowmark",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.bowmark%2Fbowmark/versions/8.112.0",
+      "description": "Do things on live websites: prices, availability, quotes, bookings, anything behind a form or login.",
+      "version": "8.112.0",
+      "updatedAt": "2026-09-11T14:15:13Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/bowmark-ai/skill#readme",
+        "repository": "https://github.com/bowmark-ai/skill",
+        "repositorySource": "github",
+        "websiteUrl": "https://bowmark.ai"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:ai.certscore:mcp-light",
+      "displayName": "CertScore.ai MCP Light",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.certscore%2Fmcp-light/versions/0.2.20",
+      "description": "Free website privacy scanner for pre-consent cookies, trackers, consent, policy, and HTTPS/TLS.",
+      "version": "0.2.20",
+      "updatedAt": "2026-09-11T14:15:28Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/ergoveritas1-alt/certscore.ai/tree/HEAD/packages/certscore-mcp",
+        "repository": "https://github.com/ergoveritas1-alt/certscore.ai",
+        "repositorySource": "github",
+        "repositorySubfolder": "packages/certscore-mcp",
+        "websiteUrl": "https://certscore.ai/mcp/light"
       }
     },
     {
@@ -22413,7 +22514,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-08-25T07:49:01Z",
+      "updatedAt": "2026-09-11T14:15:30Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22438,7 +22539,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-08-25T07:49:03Z",
+      "updatedAt": "2026-09-11T14:15:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22453,7 +22554,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-08-25T07:49:04Z",
+      "updatedAt": "2026-09-11T14:15:39Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22477,21 +22578,21 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-25T07:49:05Z",
+      "updatedAt": "2026-09-11T14:15:40Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
         "repository": "https://github.com/keenableai/keenable-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2
+        "stargazerCount": 5
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.nauro:nauro",
       "displayName": "Nauro",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.16.0",
-      "description": "Human-approved project judgment and current state for connected AI agents, surfaced before work.",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.nauro%2Fnauro/versions/1.19.0",
+      "description": "What every agent should know",
       "tags": [
         "agentic-ai",
         "ai-agents",
@@ -22503,14 +22604,14 @@
         "model-context-protocol",
         "claude-code"
       ],
-      "version": "1.16.0",
-      "updatedAt": "2026-08-25T07:49:06Z",
+      "version": "1.19.0",
+      "updatedAt": "2026-09-11T14:15:47Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
         "repository": "https://github.com/Nauro-AI/nauro",
         "repositorySource": "github",
-        "stargazerCount": 9,
+        "stargazerCount": 10,
         "websiteUrl": "https://nauro.ai"
       }
     },
@@ -22518,7 +22619,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.plori:plori",
       "displayName": "Plori",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.9.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.plori%2Fplori/versions/0.13.1",
       "description": "Create and drive plori cloud agents and workflows over MCP; each agent has its own environment.",
       "tags": [
         "ai-agents",
@@ -22527,14 +22628,43 @@
         "mcp-server",
         "model-context-protocol"
       ],
-      "version": "0.9.1",
-      "updatedAt": "2026-08-25T07:49:07Z",
+      "version": "0.13.1",
+      "updatedAt": "2026-09-11T14:15:53Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
         "repository": "https://github.com/plori-ai/plori",
         "repositorySource": "github",
         "websiteUrl": "https://plori.ai"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:ai.robosystems:robosystems",
+      "displayName": "RoboSystems",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.robosystems%2Frobosystems/versions/1.10.2",
+      "description": "Accounting knowledge graphs: SEC XBRL filings, QuickBooks ledgers, reports and forecasts over MCP.",
+      "tags": [
+        "aws",
+        "fastapi",
+        "knowledge-graph",
+        "xbrl",
+        "arelle",
+        "postgresql",
+        "financial",
+        "financial-data",
+        "financial-analysis",
+        "accounting"
+      ],
+      "version": "1.10.2",
+      "updatedAt": "2026-09-11T14:15:55Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/RoboFinSystems/robosystems#readme",
+        "repository": "https://github.com/RoboFinSystems/robosystems",
+        "repositorySource": "github",
+        "stargazerCount": 25,
+        "websiteUrl": "https://robosystems.ai"
       }
     },
     {
@@ -22546,23 +22676,23 @@
       "tags": [
         "agent-payments",
         "ai-agents",
-        "browser-automation",
         "code-sandbox",
         "deep-research",
-        "image-generation",
-        "lead-enrichment",
-        "market-research",
         "mcp",
-        "mcp-server"
+        "mcp-server",
+        "model-context-protocol",
+        "web-scraping",
+        "web-search",
+        "x402"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-08-25T07:49:08Z",
+      "updatedAt": "2026-09-11T14:15:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
         "repository": "https://github.com/vaaya-ai/vaaya-mcp",
         "repositorySource": "github",
-        "stargazerCount": 41,
+        "stargazerCount": 43,
         "websiteUrl": "https://vaaya.ai"
       }
     },
@@ -22599,7 +22729,7 @@
         "readmeUrl": "https://github.com/antfu/nuxt-mcp#readme",
         "repository": "https://github.com/antfu/nuxt-mcp",
         "repositorySource": "github",
-        "stargazerCount": 908
+        "stargazerCount": 911
       }
     },
     {
@@ -22609,7 +22739,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-08-25T07:49:09Z",
+      "updatedAt": "2026-09-11T14:16:07Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22635,12 +22765,12 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:10Z",
+      "updatedAt": "2026-09-11T14:16:08Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
         "repositorySource": "github",
-        "stargazerCount": 11,
+        "stargazerCount": 25,
         "websiteUrl": "https://mcp.desktopcommander.app"
       }
     },
@@ -22659,12 +22789,12 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:11Z",
+      "updatedAt": "2026-09-11T14:16:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 203,
+        "stargazerCount": 209,
         "websiteUrl": "https://glif.app/mcp"
       }
     },
@@ -22675,12 +22805,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:12Z",
+      "updatedAt": "2026-09-11T14:16:10Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1
+        "stargazerCount": 2
       }
     },
     {
@@ -22702,13 +22832,13 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:49:13Z",
+      "updatedAt": "2026-09-11T14:16:12Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
         "repository": "https://github.com/pensados/sentinelx-cloud-core",
         "repositorySource": "github",
-        "stargazerCount": 5
+        "stargazerCount": 8
       }
     },
     {
@@ -22724,7 +22854,7 @@
         "readmeUrl": "https://github.com/azure-ai-foundry/mcp-foundry#readme",
         "repository": "https://github.com/azure-ai-foundry/mcp-foundry",
         "repositorySource": "github",
-        "stargazerCount": 255
+        "stargazerCount": 260
       }
     },
     {
@@ -22745,7 +22875,7 @@
         "readmeUrl": "https://github.com/Azure/aks-mcp#readme",
         "repository": "https://github.com/Azure/aks-mcp",
         "repositorySource": "github",
-        "stargazerCount": 141
+        "stargazerCount": 140
       }
     },
     {
@@ -22776,15 +22906,15 @@
         "readmeUrl": "https://github.com/chroma-core/chroma-mcp#readme",
         "repository": "https://github.com/chroma-core/chroma-mcp",
         "repositorySource": "github",
-        "stargazerCount": 587
+        "stargazerCount": 592
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:cloud.dchub:mcp-server",
-      "displayName": "DC Hub — Data Center & Power Intelligence",
+      "displayName": "DC Hub — Data Center Site Selection & Colocation: Electricity, Power Grid, Gas, Fiber",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.12.0",
-      "description": "Data-center, grid, fiber & gas infrastructure intelligence for AI agents — query and cite.",
+      "url": "https://api.mcp.github.com/v0.1/servers/cloud.dchub%2Fmcp-server/versions/2.12.11",
+      "description": "Live power, energy, grid, gas, fiber & data-center site-selection infrastructure — query and cite.",
       "tags": [
         "ai-tools",
         "anthropic",
@@ -22797,8 +22927,8 @@
         "market-intelligence",
         "mcp"
       ],
-      "version": "2.12.0",
-      "updatedAt": "2026-08-25T07:49:15Z",
+      "version": "2.12.11",
+      "updatedAt": "2026-09-11T14:16:20Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22815,7 +22945,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:15Z",
+      "updatedAt": "2026-09-11T14:16:22Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22843,7 +22973,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-08-25T07:49:17Z",
+      "updatedAt": "2026-09-11T14:16:24Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -22890,14 +23020,14 @@
         "readmeUrl": "https://github.com/CognitionAI/deepwiki#readme",
         "repository": "https://github.com/CognitionAI/deepwiki",
         "repositorySource": "github",
-        "stargazerCount": 88
+        "stargazerCount": 93
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.apify:apify-mcp-server",
       "displayName": "Apify",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.apify%2Fapify-mcp-server/versions/0.15.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.apify%2Fapify-mcp-server/versions/0.15.7",
       "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
       "tags": [
         "agents",
@@ -22905,22 +23035,22 @@
         "mcp",
         "mcp-server"
       ],
-      "version": "0.15.1",
-      "updatedAt": "2026-08-25T07:49:18Z",
+      "version": "0.15.7",
+      "updatedAt": "2026-09-11T14:16:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4839
+        "stargazerCount": 6756
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.atlassian:atlassian-mcp-server",
       "displayName": "Atlassian Rovo MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.atlassian%2Fatlassian-mcp-server/versions/1.1.3",
-      "description": "Connect to Atlassian Jira, Confluence, and Compass to search, create, and manage your work.",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.atlassian%2Fatlassian-mcp-server/versions/2.0.0",
+      "description": "Connect to Atlassian Jira, Confluence, Loom, and more to search, create, and manage your work.",
       "tags": [
         "ai",
         "ai-agents",
@@ -22933,14 +23063,14 @@
         "copilot",
         "cursor"
       ],
-      "version": "1.1.3",
-      "updatedAt": "2026-08-25T07:49:19Z",
+      "version": "2.0.0",
+      "updatedAt": "2026-09-11T14:16:30Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
         "repository": "https://github.com/atlassian/atlassian-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 983,
+        "stargazerCount": 1033,
         "websiteUrl": "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/"
       }
     },
@@ -22951,7 +23081,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-08-25T07:49:20Z",
+      "updatedAt": "2026-09-11T14:16:32Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -22966,12 +23096,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:22Z",
+      "updatedAt": "2026-09-11T14:16:33Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/atc"
       }
     },
@@ -22982,12 +23112,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:22Z",
+      "updatedAt": "2026-09-11T14:16:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/avatax"
       }
     },
@@ -22998,12 +23128,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:23Z",
+      "updatedAt": "2026-09-11T14:16:35Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/business_licensing"
       }
     },
@@ -23014,12 +23144,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:25Z",
+      "updatedAt": "2026-09-11T14:16:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/classification"
       }
     },
@@ -23030,12 +23160,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:49:26Z",
+      "updatedAt": "2026-09-11T14:16:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/cross-border"
       }
     },
@@ -23046,13 +23176,29 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:26Z",
+      "updatedAt": "2026-09-11T14:16:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/docs"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.avalara:elr",
+      "displayName": "Avalara E-Invoicing & Live Reporting",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Felr/versions/1.0.0",
+      "description": "Provides access to Avalara E-Invoicing and Live Reporting APIs for document statuses and compliance",
+      "version": "1.0.0",
+      "updatedAt": "2026-09-11T14:16:40Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/avadev/mcp#readme",
+        "repository": "https://github.com/avadev/mcp",
+        "repositorySource": "github",
+        "stargazerCount": 4,
+        "websiteUrl": "https://developer.avalara.com/mcp-servers/E-Invoicing"
       }
     },
     {
@@ -23062,12 +23208,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:27Z",
+      "updatedAt": "2026-09-11T14:16:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developer.avalara.com/mcp-servers/returns"
       }
     },
@@ -23078,7 +23224,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-08-25T07:49:29Z",
+      "updatedAt": "2026-09-11T14:16:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23092,13 +23238,38 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-25T07:49:30Z",
+      "updatedAt": "2026-09-11T14:16:44Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
         "repository": "https://github.com/durwardjohnson/breckenwander-travel-connector",
         "repositorySource": "github",
         "websiteUrl": "https://breckenwander.com"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.celigo:celigo",
+      "displayName": "Celigo",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.celigo%2Fceligo/versions/0.6.1",
+      "description": "Manage your Celigo integrator.io account: integrations, flows, connections, errors, and jobs.",
+      "tags": [
+        "agent-skills",
+        "ai",
+        "celigo",
+        "integrations",
+        "llm",
+        "mcp"
+      ],
+      "version": "0.6.1",
+      "updatedAt": "2026-09-11T14:16:45Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/celigo/ai#readme",
+        "repository": "https://github.com/celigo/ai",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/celigo/ai/blob/main/docs/connect-mcp.md"
       }
     },
     {
@@ -23118,12 +23289,12 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-08-25T07:49:31Z",
+      "updatedAt": "2026-09-11T14:16:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://docs.chainstack.com/docs/chainstack-mcp-server"
       }
     },
@@ -23146,7 +23317,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:49:32Z",
+      "updatedAt": "2026-09-11T14:16:48Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23163,7 +23334,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-08-25T07:49:33Z",
+      "updatedAt": "2026-09-11T14:16:49Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23177,13 +23348,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:34Z",
+      "updatedAt": "2026-09-11T14:16:50Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
         "repository": "https://github.com/figma/mcp-server-guide",
         "repositorySource": "github",
-        "stargazerCount": 1919
+        "stargazerCount": 1977
       }
     },
     {
@@ -23204,7 +23375,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-25T07:49:35Z",
+      "updatedAt": "2026-09-11T14:16:52Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -23220,7 +23391,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:49:36Z",
+      "updatedAt": "2026-09-11T14:16:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -23235,7 +23406,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:49:37Z",
+      "updatedAt": "2026-09-11T14:16:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -23260,12 +23431,12 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:38Z",
+      "updatedAt": "2026-09-11T14:16:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2,
+        "stargazerCount": 3,
         "websiteUrl": "https://www.getwpagent.com/docs"
       }
     },
@@ -23286,12 +23457,12 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-08-25T07:49:39Z",
+      "updatedAt": "2026-09-11T14:16:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 164,
+        "stargazerCount": 165,
         "websiteUrl": "https://docs.glean.com/administration/platform/mcp/enable-mcp-servers"
       }
     },
@@ -23302,7 +23473,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-08-25T07:49:40Z",
+      "updatedAt": "2026-09-11T14:16:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -23314,7 +23485,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.imnoo:drawing-converter",
       "displayName": "Imnoo Drawing Converter",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.imnoo%2Fdrawing-converter/versions/0.1.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.imnoo%2Fdrawing-converter/versions/0.1.1",
       "description": "Metric ⇄ imperial for technical drawings: dimensions, tolerances, ISO fits, threads, roughness.",
       "tags": [
         "cnc",
@@ -23328,14 +23499,29 @@
         "pdf",
         "technical-drawing"
       ],
-      "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:49:41Z",
+      "version": "0.1.1",
+      "updatedAt": "2026-09-11T14:17:00Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
         "repository": "https://github.com/imnoo-team/drawing-converter-mcp",
         "repositorySource": "github",
         "websiteUrl": "https://metric-to-imperial-converter.imnoo.com"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.industry-lens:mcp-public",
+      "displayName": "IndustryLens",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.industry-lens%2Fmcp-public/versions/0.2.0",
+      "description": "B2B SaaS competitor pricing changes, strategic moves, market landscapes, reports and comparisons.",
+      "version": "0.2.0",
+      "updatedAt": "2026-09-11T14:17:01Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/IndustryLensOp/industrylens-mcp-docs#readme",
+        "repository": "https://github.com/IndustryLensOp/industrylens-mcp-docs",
+        "repositorySource": "github",
+        "websiteUrl": "https://industry-lens.com"
       }
     },
     {
@@ -23353,13 +23539,13 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-08-25T07:49:42Z",
+      "updatedAt": "2026-09-11T14:17:04Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
         "repository": "https://github.com/longbridge/longbridge-mcp",
         "repositorySource": "github",
-        "stargazerCount": 12,
+        "stargazerCount": 13,
         "websiteUrl": "https://longbridge.com"
       }
     },
@@ -23373,7 +23559,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:49:44Z",
+      "updatedAt": "2026-09-11T14:17:06Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23400,13 +23586,13 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:45Z",
+      "updatedAt": "2026-09-11T14:17:07Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
         "repository": "https://github.com/macfax/macfax-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://macfax.com/developers"
       }
     },
@@ -23414,7 +23600,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.mailrith:mailrith",
       "displayName": "Mailrith Email Marketing",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.1.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.mailrith%2Fmailrith/versions/1.1.1",
       "description": "Manage Subscribers, Broadcasts, Sequences, Automations, and reporting in Mailrith.",
       "tags": [
         "ai-agents",
@@ -23425,15 +23611,14 @@
         "typescript",
         "gemini-cli-extension"
       ],
-      "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:49:46Z",
+      "version": "1.1.1",
+      "updatedAt": "2026-09-11T14:17:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/anrawool/mailrith-agent-platform",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 1,
         "websiteUrl": "https://mailrith.com/developers/mcp"
       }
     },
@@ -23452,7 +23637,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-08-25T07:49:47Z",
+      "updatedAt": "2026-09-11T14:17:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23465,17 +23650,17 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.microsoft:azure",
       "displayName": "Azure MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.37",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.42",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
-      "version": "3.0.0-beta.37",
-      "updatedAt": "2026-08-25T07:49:48Z",
+      "version": "3.0.0-beta.42",
+      "updatedAt": "2026-09-11T14:17:11Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Azure.Mcp.Server",
-        "stargazerCount": 3600,
+        "stargazerCount": 3665,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server"
       }
     },
@@ -23483,17 +23668,17 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.microsoft:microsoft-fabric",
       "displayName": "Microsoft Fabric MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.3.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.4.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
-      "version": "1.3.0",
-      "updatedAt": "2026-08-25T07:49:50Z",
+      "version": "1.4.0",
+      "updatedAt": "2026-09-11T14:17:13Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Fabric.Mcp.Server",
-        "stargazerCount": 3600,
+        "stargazerCount": 3665,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
       }
     },
@@ -23504,7 +23689,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-08-25T07:49:51Z",
+      "updatedAt": "2026-09-11T14:17:14Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
@@ -23521,7 +23706,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:52Z",
+      "updatedAt": "2026-09-11T14:17:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23540,12 +23725,12 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:49:53Z",
+      "updatedAt": "2026-09-11T14:17:17Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 30
+        "stargazerCount": 38
       }
     },
     {
@@ -23562,21 +23747,21 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-08-25T07:49:54Z",
+      "updatedAt": "2026-09-11T14:17:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
         "repository": "https://github.com/mondaycom/mcp",
         "repositorySource": "github",
-        "stargazerCount": 420
+        "stargazerCount": 424
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.negativeev:bet-checker",
-      "displayName": "Negativeev Bet Checker",
+      "displayName": "NegativeEV bet checker",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.3",
-      "description": "Grade any MLB, WNBA, PGA or ATP bet against thousands of play-by-play game simulations.",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.negativeev%2Fbet-checker/versions/1.4.5",
+      "description": "Grade any MLB, WNBA, PGA or ATP bet against thousands of play-by-play sims. No key, no signup.",
       "tags": [
         "claude",
         "mcp",
@@ -23584,13 +23769,30 @@
         "simulation",
         "sports-betting"
       ],
-      "version": "1.4.3",
-      "updatedAt": "2026-08-25T07:49:55Z",
+      "version": "1.4.5",
+      "updatedAt": "2026-09-11T14:17:19Z",
       "metadata": {
-        "readmeUrl": "https://github.com/negative-ev/negativeev-mcp#readme",
-        "repository": "https://github.com/negative-ev/negativeev-mcp",
+        "readmeUrl": "https://github.com/jessejohnsohn/negativeev-mcp#readme",
+        "repository": "https://github.com/jessejohnsohn/negativeev-mcp",
         "repositorySource": "github",
         "websiteUrl": "https://negativeev.com"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.nitrosend:nitrosend",
+      "displayName": "Nitrosend",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.nitrosend%2Fnitrosend/versions/0.8.2",
+      "description": "AI-native email marketing. Campaigns, automations, transactional, contacts, and analytics.",
+      "version": "0.8.2",
+      "updatedAt": "2026-09-11T14:17:21Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/nitrosend/mcp#readme",
+        "repository": "https://github.com/nitrosend/mcp",
+        "repositorySource": "github",
+        "stargazerCount": 2,
+        "websiteUrl": "https://nitrosend.com"
       }
     },
     {
@@ -23600,7 +23802,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:49:56Z",
+      "updatedAt": "2026-09-11T14:17:22Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23610,10 +23812,10 @@
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.postman:postman-mcp-server",
-      "displayName": "Postman",
+      "displayName": "Postman MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.postman%2Fpostman-mcp-server/versions/2.12.0",
-      "description": "A basic MCP server to operate on the Postman API.",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.postman%2Fpostman-mcp-server/versions/2.12.3",
+      "description": "Give your AI agents trusted access to the full Postman platform.",
       "tags": [
         "ai",
         "mcp",
@@ -23626,14 +23828,15 @@
         "claude-code",
         "copilot"
       ],
-      "version": "2.12.0",
-      "updatedAt": "2026-08-25T07:49:57Z",
+      "version": "2.12.3",
+      "updatedAt": "2026-09-11T14:17:24Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
         "repository": "https://github.com/postmanlabs/postman-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 307
+        "stargazerCount": 312,
+        "websiteUrl": "https://www.postman.com/product/mcp-server/"
       }
     },
     {
@@ -23643,7 +23846,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-25T07:49:58Z",
+      "updatedAt": "2026-09-11T14:17:25Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23672,7 +23875,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:00Z",
+      "updatedAt": "2026-09-11T14:17:27Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23697,7 +23900,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:01Z",
+      "updatedAt": "2026-09-11T14:17:29Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23723,7 +23926,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:50:02Z",
+      "updatedAt": "2026-09-11T14:17:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23736,10 +23939,10 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.sherweb:platform",
       "displayName": "Sherweb Platform MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.47.27",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.52.10",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
-      "version": "1.47.27",
-      "updatedAt": "2026-08-25T07:50:03Z",
+      "version": "1.52.10",
+      "updatedAt": "2026-09-11T14:17:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23751,7 +23954,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.shipstatic:mcp",
       "displayName": "ShipStatic",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.shipstatic%2Fmcp/versions/1.3.5",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.shipstatic%2Fmcp/versions/1.10.2",
       "description": "Deploy static websites from AI agents. Free at mcp.shipstatic.com — no install, no signup.",
       "tags": [
         "ai",
@@ -23765,14 +23968,14 @@
         "static-hosting",
         "static-site"
       ],
-      "version": "1.3.5",
-      "updatedAt": "2026-08-25T07:50:04Z",
+      "version": "1.10.2",
+      "updatedAt": "2026-09-11T14:17:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
         "repository": "https://github.com/shipstatic/mcp",
         "repositorySource": "github",
-        "stargazerCount": 6,
+        "stargazerCount": 7,
         "websiteUrl": "https://shipstatic.com"
       }
     },
@@ -23780,7 +23983,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.smartbear:smartbear-mcp",
       "displayName": "SmartBear MCP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.smartbear%2Fsmartbear-mcp/versions/0.37.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.smartbear%2Fsmartbear-mcp/versions/0.40.0",
       "description": "MCP server for AI access to SmartBear tools, including BugSnag, Reflect, Swagger, PactFlow, QTM4J.",
       "tags": [
         "bugsnag",
@@ -23794,14 +23997,14 @@
         "portal",
         "swagger"
       ],
-      "version": "0.37.0",
-      "updatedAt": "2026-08-25T07:50:05Z",
+      "version": "0.40.0",
+      "updatedAt": "2026-09-11T14:17:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
         "repository": "https://github.com/SmartBear/smartbear-mcp",
         "repositorySource": "github",
-        "stargazerCount": 43
+        "stargazerCount": 44
       }
     },
     {
@@ -23823,13 +24026,13 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-08-25T07:50:07Z",
+      "updatedAt": "2026-09-11T14:17:37Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
         "repository": "https://github.com/SmartBear/smartbear-mcp",
         "repositorySource": "github",
-        "stargazerCount": 43
+        "stargazerCount": 44
       }
     },
     {
@@ -23839,7 +24042,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:08Z",
+      "updatedAt": "2026-09-11T14:17:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -23857,13 +24060,13 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-08-25T07:50:09Z",
+      "updatedAt": "2026-09-11T14:17:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/knowledge",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://developers.soracom.io/en/docs/tools/knowledge-mcp-server/"
       }
     },
@@ -23874,13 +24077,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-08-25T07:50:10Z",
+      "updatedAt": "2026-09-11T14:17:40Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
         "repository": "https://github.com/stackhawk/stackhawk-mcp",
         "repositorySource": "github",
-        "stargazerCount": 9
+        "stargazerCount": 10
       }
     },
     {
@@ -23890,12 +24093,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-08-25T07:50:11Z",
+      "updatedAt": "2026-09-11T14:17:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
         "repositorySource": "github",
-        "stargazerCount": 22
+        "stargazerCount": 23
       }
     },
     {
@@ -23915,30 +24118,30 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-08-25T07:50:12Z",
+      "updatedAt": "2026-09-11T14:17:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
         "repository": "https://github.com/stripe/agent-toolkit",
         "repositorySource": "github",
-        "stargazerCount": 1763
+        "stargazerCount": 1798
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.supabase:mcp",
       "displayName": "Supabase",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.11.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.12.0",
       "description": "MCP server for interacting with the Supabase platform",
-      "version": "0.11.0",
-      "updatedAt": "2026-08-25T07:50:13Z",
+      "version": "0.12.0",
+      "updatedAt": "2026-09-11T14:17:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
         "repository": "https://github.com/supabase/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server-supabase",
-        "stargazerCount": 2871,
+        "stargazerCount": 2902,
         "websiteUrl": "https://supabase.com/mcp"
       }
     },
@@ -23946,15 +24149,16 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:com.tallyfy:mcp-server",
       "displayName": "Tallyfy Workflow Automation",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.1.2",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.2.0",
       "description": "Automate tasks, processes, and approvals with AI.",
-      "version": "1.1.2",
-      "updatedAt": "2026-08-25T07:50:15Z",
+      "version": "1.2.0",
+      "updatedAt": "2026-09-11T14:17:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
         "repository": "https://github.com/tallyfy/mcp-public",
         "repositorySource": "github",
+        "stargazerCount": 1,
         "websiteUrl": "https://tallyfy.com/products/pro/integrations/mcp-server/"
       }
     },
@@ -23965,12 +24169,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-08-25T07:50:16Z",
+      "updatedAt": "2026-09-11T14:17:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
         "repositorySource": "github",
-        "stargazerCount": 12
+        "stargazerCount": 13
       }
     },
     {
@@ -23987,13 +24191,13 @@
         "business-critical-yes"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:50:17Z",
+      "updatedAt": "2026-09-11T14:17:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/webflow/mcp-server#readme",
         "repository": "https://github.com/webflow/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 137
+        "stargazerCount": 139
       }
     },
     {
@@ -24003,12 +24207,34 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.wix%2Fmcp/versions/1.0.2",
       "description": "A Model Context Protocol server for Wix AI tools",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:18Z",
+      "updatedAt": "2026-09-11T14:17:50Z",
       "metadata": {
         "readmeUrl": "https://github.com/wix/wix-mcp#readme",
         "repository": "https://github.com/wix/wix-mcp",
         "repositorySource": "github",
         "stargazerCount": 16
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:com.workos:mcp",
+      "displayName": "WorkOS",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/com.workos%2Fmcp/versions/1.0.0",
+      "description": "Manage your WorkOS workspace in plain language: orgs, users, SSO, Directory Sync, and AuthKit.",
+      "tags": [
+        "cli",
+        "dax"
+      ],
+      "version": "1.0.0",
+      "updatedAt": "2026-09-11T14:17:51Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/workos/skills/tree/HEAD/mcp",
+        "repository": "https://github.com/workos/skills",
+        "repositorySource": "github",
+        "repositorySubfolder": "mcp",
+        "stargazerCount": 46,
+        "websiteUrl": "https://workos.com/docs/mcp"
       }
     },
     {
@@ -24030,12 +24256,12 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:50:19Z",
+      "updatedAt": "2026-09-11T14:17:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://www.wpwriter.com/docs/mcp"
       }
     },
@@ -24056,7 +24282,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-08-25T07:50:20Z",
+      "updatedAt": "2026-09-11T14:17:54Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -24084,13 +24310,13 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-08-25T07:50:21Z",
+      "updatedAt": "2026-09-11T14:17:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
         "repository": "https://github.com/Xquik-dev/x-twitter-scraper",
         "repositorySource": "github",
-        "stargazerCount": 187,
+        "stargazerCount": 195,
         "websiteUrl": "https://docs.xquik.com/mcp/overview"
       }
     },
@@ -24119,7 +24345,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 13634
+        "stargazerCount": 14133
       }
     },
     {
@@ -24139,12 +24365,12 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:50:22Z",
+      "updatedAt": "2026-09-11T14:17:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
         "repositorySource": "github",
-        "stargazerCount": 3,
+        "stargazerCount": 4,
         "websiteUrl": "https://lovable.dev"
       }
     },
@@ -24165,7 +24391,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-08-25T07:50:24Z",
+      "updatedAt": "2026-09-11T14:18:00Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -24175,20 +24401,47 @@
       }
     },
     {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:dev.slideforge:slideforge",
+      "displayName": "SlideForge",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/dev.slideforge%2Fslideforge/versions/5.9.0",
+      "description": "Deterministic, fully editable PowerPoint from typed slide intents. 200+ layouts, brand templates.",
+      "tags": [
+        "agent-skills",
+        "ai-agents",
+        "claude",
+        "claude-code",
+        "mcp",
+        "mcp-server",
+        "powerpoint",
+        "pptx",
+        "presentations"
+      ],
+      "version": "5.9.0",
+      "updatedAt": "2026-09-11T14:18:01Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/smartdatabrokers/slideforge-mcp#readme",
+        "repository": "https://github.com/smartdatabrokers/slideforge-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 4
+      }
+    },
+    {
       "identifier": "urn:air:registry.modelcontextprotocol.io:dev.svelte:mcp",
       "displayName": "Svelte MCP",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/dev.svelte%2Fmcp/versions/0.1.26",
       "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
       "version": "0.1.26",
-      "updatedAt": "2026-08-25T07:50:25Z",
+      "updatedAt": "2026-09-11T14:18:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/sveltejs/ai-tools/tree/HEAD/packages/mcp-stdio",
         "repository": "https://github.com/sveltejs/ai-tools",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-stdio",
-        "stargazerCount": 309,
+        "stargazerCount": 322,
         "websiteUrl": "https://svelte.dev/docs/mcp/overview"
       }
     },
@@ -24199,7 +24452,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:50:26Z",
+      "updatedAt": "2026-09-11T14:18:04Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -24221,7 +24474,7 @@
         "readmeUrl": "https://github.com/Doist/todoist-ai#readme",
         "repository": "https://github.com/Doist/todoist-ai",
         "repositorySource": "github",
-        "stargazerCount": 537
+        "stargazerCount": 545
       }
     },
     {
@@ -24243,7 +24496,34 @@
         "readmeUrl": "https://github.com/elastic/mcp-server-elasticsearch#readme",
         "repository": "https://github.com/elastic/mcp-server-elasticsearch",
         "repositorySource": "github",
-        "stargazerCount": 705
+        "stargazerCount": 713
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:email.palisade:palisade",
+      "displayName": "Palisade",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/email.palisade%2Fpalisade/versions/1.0.6",
+      "description": "Monitor and manage email authentication (SPF, DKIM, DMARC, MTA-STS, BIMI) for your domains.",
+      "tags": [
+        "bimi",
+        "dkim",
+        "dmarc",
+        "dns",
+        "email-security",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "spf"
+      ],
+      "version": "1.0.6",
+      "updatedAt": "2026-09-11T14:18:07Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/palisadeemail/palisade-mcp#readme",
+        "repository": "https://github.com/palisadeemail/palisade-mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://www.palisade.email/mcp"
       }
     },
     {
@@ -24253,12 +24533,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-08-25T07:50:27Z",
+      "updatedAt": "2026-09-11T14:18:09Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 2,
         "websiteUrl": "https://ansvar.eu"
       }
     },
@@ -24287,7 +24567,7 @@
         "readmeUrl": "https://github.com/firecrawl/firecrawl-mcp-server#readme",
         "repository": "https://github.com/firecrawl/firecrawl-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 7310
+        "stargazerCount": 7435
       }
     },
     {
@@ -24303,7 +24583,7 @@
         "voice-agents"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-08-25T07:50:28Z",
+      "updatedAt": "2026-09-11T14:18:13Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/saaslabsco/justcall-mcp-server#readme",
@@ -24326,7 +24606,7 @@
         "readmeUrl": "https://github.com/huggingface/hf-mcp-server#readme",
         "repository": "https://github.com/huggingface/hf-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 278
+        "stargazerCount": 293
       }
     },
     {
@@ -24363,13 +24643,97 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-08-25T07:50:29Z",
+      "updatedAt": "2026-09-11T14:18:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
         "repository": "https://github.com/RapierCraft/alterlab-mcp-server",
         "repositorySource": "github",
         "stargazerCount": 1
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.apitube:news",
+      "displayName": "APITube News",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.apitube%2Fnews/versions/1.0.1",
+      "description": "Real-time news search across 500,000+ sources in 60+ languages with sentiment and entities.",
+      "tags": [
+        "ai-agents",
+        "claude-code",
+        "codex",
+        "cursor",
+        "llm-tools",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "news",
+        "news-api"
+      ],
+      "version": "1.0.1",
+      "updatedAt": "2026-09-11T14:18:19Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/apitube/news-api-mcp#readme",
+        "repository": "https://github.com/apitube/news-api-mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://docs.apitube.io/platform/news-api/ai/mcp-server"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.appllama:appllama",
+      "displayName": "Appllama",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.appllama%2Fappllama/versions/1.0.1",
+      "description": "Study screens, flows and paywalls from top-earning iOS apps, then build from what wins.",
+      "tags": [
+        "agent-skills",
+        "ai-agents",
+        "claude",
+        "claude-code",
+        "claude-code-skill",
+        "claude-skills",
+        "codex",
+        "codex-skill",
+        "cursor",
+        "design-system"
+      ],
+      "version": "1.0.1",
+      "updatedAt": "2026-09-11T14:18:21Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/Appllama/appllama-skills#readme",
+        "repository": "https://github.com/Appllama/appllama-skills",
+        "repositorySource": "github",
+        "stargazerCount": 1498,
+        "websiteUrl": "https://appllama.io/mcp"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.contextstream:mcp",
+      "displayName": "ContextStream",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.contextstream%2Fmcp/versions/0.5.35",
+      "description": "Persistent memory and cross-session learning for AI coding assistants (hosted remote MCP).",
+      "tags": [
+        "ai-memory",
+        "claude",
+        "context-management",
+        "cursor",
+        "mcp",
+        "windsurf",
+        "gemini-cli-extension",
+        "agent",
+        "agentmemory",
+        "context"
+      ],
+      "version": "0.5.35",
+      "updatedAt": "2026-09-11T14:18:22Z",
+      "metadata": {
+        "primaryLanguage": "Rust",
+        "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
+        "repository": "https://github.com/contextstream/mcp-server",
+        "repositorySource": "github",
+        "stargazerCount": 43,
+        "websiteUrl": "https://contextstream.io/docs/mcp"
       }
     },
     {
@@ -24391,7 +24755,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:50:30Z",
+      "updatedAt": "2026-09-11T14:18:23Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24420,7 +24784,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:50:31Z",
+      "updatedAt": "2026-09-11T14:18:25Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24434,7 +24798,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.frihet:erp",
       "displayName": "Frihet ERP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.frihet%2Ferp/versions/1.16.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.frihet%2Ferp/versions/1.17.0",
       "description": "AI-native ERP MCP: ES/EU fiscal compliance (VeriFactu/TicketBAI/Facturae), invoicing, tax, banking",
       "tags": [
         "ai",
@@ -24448,8 +24812,8 @@
         "business-management",
         "ai-native"
       ],
-      "version": "1.16.3",
-      "updatedAt": "2026-08-25T07:50:33Z",
+      "version": "1.17.0",
+      "updatedAt": "2026-09-11T14:18:26Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24462,7 +24826,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.AlvisoOculus:optionsahoy-mcp",
       "displayName": "AlvisoOculus Optionsahoy",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.AlvisoOculus%2Foptionsahoy-mcp/versions/1.10.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.AlvisoOculus%2Foptionsahoy-mcp/versions/1.10.2",
       "description": "Equity comp tax/trade optimizer: ISO/AMT exercise, NSO, RSU, QSBS, concentration, hedging. 50-state.",
       "tags": [
         "equity-compensation",
@@ -24476,8 +24840,8 @@
         "finance",
         "model-context-protocol"
       ],
-      "version": "1.10.1",
-      "updatedAt": "2026-08-25T07:50:34Z",
+      "version": "1.10.2",
+      "updatedAt": "2026-09-11T14:18:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24494,7 +24858,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AnimaApp%2Fanima/versions/1.0.0",
       "description": "Connect AI coding agents to Anima Playground, Figma, and your design system.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:35Z",
+      "updatedAt": "2026-09-11T14:18:29Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/AnimaApp/mcp-server-guide#readme",
@@ -24504,13 +24868,41 @@
       }
     },
     {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Bitget-AI:bitget-agent-mcp",
+      "displayName": "Bitget Agent",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Bitget-AI%2Fbitget-agent-mcp/versions/3.0.2",
+      "description": "Official Bitget MCP Server for the Unified Trading Account (UTA v3) API.",
+      "tags": [
+        "ai-agent",
+        "bitget",
+        "chatgpt",
+        "claude-desktop",
+        "crypto-trading",
+        "cursor",
+        "mcp",
+        "model-context-protocol",
+        "typescript",
+        "uta-v3"
+      ],
+      "version": "3.0.2",
+      "updatedAt": "2026-09-11T14:18:30Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/Bitget-AI/agent-mcp#readme",
+        "repository": "https://github.com/Bitget-AI/agent-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 1
+      }
+    },
+    {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.CAST-Extend:imaging-mcp-server",
       "displayName": "CAST Imaging MCP Server",
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-08-25T07:50:36Z",
+      "updatedAt": "2026-09-11T14:18:31Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24522,7 +24914,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.ChromeDevTools:chrome-devtools-mcp",
       "displayName": "Chrome DevTools MCP",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ChromeDevTools%2Fchrome-devtools-mcp/versions/1.7.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ChromeDevTools%2Fchrome-devtools-mcp/versions/1.9.0",
       "description": "MCP server for Chrome DevTools",
       "tags": [
         "mcp-server",
@@ -24534,30 +24926,30 @@
         "devtools",
         "mcp"
       ],
-      "version": "1.7.0",
-      "updatedAt": "2026-08-25T07:50:38Z",
+      "version": "1.9.0",
+      "updatedAt": "2026-09-11T14:18:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ChromeDevTools/chrome-devtools-mcp#readme",
         "repository": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 49671
+        "stargazerCount": 51641
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.ClickHouse:mcp-clickhouse",
       "displayName": "ClickHouse",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.4.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.6.0",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
-      "version": "0.4.1",
-      "updatedAt": "2026-08-25T07:50:39Z",
+      "version": "0.6.0",
+      "updatedAt": "2026-09-11T14:18:35Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
         "repository": "https://github.com/ClickHouse/mcp-clickhouse",
         "repositorySource": "github",
-        "stargazerCount": 857,
+        "stargazerCount": 870,
         "websiteUrl": "https://clickhouse.com"
       }
     },
@@ -24568,12 +24960,12 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-08-25T07:50:40Z",
+      "updatedAt": "2026-09-11T14:18:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
         "repositorySource": "github",
-        "stargazerCount": 1,
+        "stargazerCount": 3,
         "websiteUrl": "https://composio.dev"
       }
     },
@@ -24581,7 +24973,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.CrowdStrike:falcon-mcp",
       "displayName": "CrowdStrike Falcon MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.CrowdStrike%2Ffalcon-mcp/versions/0.17.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.CrowdStrike%2Ffalcon-mcp/versions/0.19.0",
       "description": "Connects AI agents with CrowdStrike Falcon for security analysis and automation.",
       "tags": [
         "ai",
@@ -24590,14 +24982,14 @@
         "mcp",
         "mcp-server"
       ],
-      "version": "0.17.0",
-      "updatedAt": "2026-08-25T07:50:41Z",
+      "version": "0.19.0",
+      "updatedAt": "2026-09-11T14:18:38Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/CrowdStrike/falcon-mcp#readme",
         "repository": "https://github.com/CrowdStrike/falcon-mcp",
         "repositorySource": "github",
-        "stargazerCount": 239
+        "stargazerCount": 250
       }
     },
     {
@@ -24619,20 +25011,121 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-08-25T07:50:44Z",
+      "updatedAt": "2026-09-11T14:18:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
         "repository": "https://github.com/Decodo/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 34
+        "stargazerCount": 36
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Dynatrace:dynatrace-for-ai",
+      "displayName": "Dynatrace",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Dynatrace%2Fdynatrace-for-ai/versions/7.0.0",
+      "description": "Connect AI assistants to Dynatrace to query observability data and analyze problems.",
+      "tags": [
+        "agent-skills",
+        "ai-agents",
+        "claude-code",
+        "devops",
+        "dql",
+        "dynatrace",
+        "mcp",
+        "observability"
+      ],
+      "version": "7.0.0",
+      "updatedAt": "2026-09-11T14:18:41Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/Dynatrace/dynatrace-for-ai#readme",
+        "repository": "https://github.com/Dynatrace/dynatrace-for-ai",
+        "repositorySource": "github",
+        "stargazerCount": 137,
+        "websiteUrl": "https://docs.dynatrace.com/docs/shortlink/dynatrace-mcp-server"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Guruprasath-Annadurai:whitepact",
+      "displayName": "WhitePact",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Guruprasath-Annadurai%2Fwhitepact/versions/1.2.3",
+      "description": "AI governance MCP server: trust scoring, guardrails, bias/hallucination detection, compliance.",
+      "tags": [
+        "ai-safety",
+        "responsible-ai",
+        "ai-governance",
+        "mcp-server",
+        "agentic-ai",
+        "ai-agents",
+        "ai-security",
+        "llm-security",
+        "mcp",
+        "openssf"
+      ],
+      "version": "1.2.3",
+      "updatedAt": "2026-09-11T14:18:44Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/Guruprasath-Annadurai/Whitepact#readme",
+        "repository": "https://github.com/Guruprasath-Annadurai/Whitepact",
+        "repositorySource": "github",
+        "stargazerCount": 1,
+        "websiteUrl": "https://github.com/Guruprasath-Annadurai/Whitepact"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.HYPD-AI:ads",
+      "displayName": "HYPD AI - Paid Ads & Analytics",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.HYPD-AI%2Fads/versions/1.2.5",
+      "description": "Google Ads, Meta (Facebook) Ads, GA4 and Merchant Center analysis in plain language. Read-only.",
+      "tags": [
+        "ads",
+        "ads-mcp",
+        "advertising",
+        "ai-ads",
+        "ai-agent",
+        "claude",
+        "claude-code",
+        "claude-plugin",
+        "facebook-ads",
+        "ga4"
+      ],
+      "version": "1.2.5",
+      "updatedAt": "2026-09-11T14:18:45Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/HYPD-AI/ads-mcp-plugin#readme",
+        "repository": "https://github.com/HYPD-AI/ads-mcp-plugin",
+        "repositorySource": "github",
+        "stargazerCount": 2,
+        "websiteUrl": "https://www.hypd.ai"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.IgniteUI:igniteui-theming",
+      "displayName": "Ignite UI Theming MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Figniteui-theming/versions/29.0.0",
+      "description": "Generate Sass palettes, typography, elevations, and themes for Ignite UI components.",
+      "version": "29.0.0",
+      "updatedAt": "2026-09-11T14:18:46Z",
+      "metadata": {
+        "primaryLanguage": "SCSS",
+        "readmeUrl": "https://github.com/IgniteUI/igniteui-theming#readme",
+        "repository": "https://github.com/IgniteUI/igniteui-theming",
+        "repositorySource": "github",
+        "stargazerCount": 44,
+        "websiteUrl": "https://github.com/IgniteUI/igniteui-theming#readme"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.IgniteUI:mcp-server",
       "displayName": "Ignite UI MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Fmcp-server/versions/15.5.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Fmcp-server/versions/15.6.1",
       "description": "Unified MCP server for Ignite UI — documentation, API, and CLI scaffolding",
       "tags": [
         "cli",
@@ -24644,8 +25137,8 @@
         "test-automation",
         "scaffolding"
       ],
-      "version": "15.5.1",
-      "updatedAt": "2026-08-25T07:50:46Z",
+      "version": "15.6.1",
+      "updatedAt": "2026-09-11T14:18:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -24673,7 +25166,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-08-25T07:50:47Z",
+      "updatedAt": "2026-09-11T14:18:49Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -24689,13 +25182,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-08-25T07:50:48Z",
+      "updatedAt": "2026-09-11T14:18:50Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
         "repository": "https://github.com/Krv-Labs/topos",
         "repositorySource": "github",
-        "stargazerCount": 24,
+        "stargazerCount": 25,
         "websiteUrl": "https://github.com/Krv-Labs/topos"
       }
     },
@@ -24718,7 +25211,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:50Z",
+      "updatedAt": "2026-09-11T14:18:52Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -24746,7 +25239,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-08-25T07:50:51Z",
+      "updatedAt": "2026-09-11T14:18:54Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -24765,7 +25258,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:50:52Z",
+      "updatedAt": "2026-09-11T14:18:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -24779,15 +25272,36 @@
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Omnidim%2Fomnidim-mcp-server/versions/0.8.0",
       "description": "Official MCP server for OmniDimension. Drive voice agents, dispatch calls, and run bulk campaigns.",
+      "tags": [
+        "mcp-server",
+        "voice-assistant"
+      ],
       "version": "0.8.0",
-      "updatedAt": "2026-08-25T07:50:53Z",
+      "updatedAt": "2026-09-11T14:18:57Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
         "repository": "https://github.com/Omnidim/omnidim-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 6,
+        "stargazerCount": 7,
         "websiteUrl": "https://omnidim.io"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Openly-Useful:citewire",
+      "displayName": "CiteWire",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Openly-Useful%2Fcitewire/versions/0.2.0",
+      "description": "Attribution-first MCP server for free news sources and free article APIs.",
+      "version": "0.2.0",
+      "updatedAt": "2026-09-11T14:18:59Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/Openly-Useful/citewire#readme",
+        "repository": "https://github.com/Openly-Useful/citewire",
+        "repositorySource": "github",
+        "stargazerCount": 1,
+        "websiteUrl": "https://citewire.org"
       }
     },
     {
@@ -24797,7 +25311,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.PagerDuty%2Fpagerduty-mcp/versions/0.2.1",
       "description": "PagerDuty's official MCP server which provides tools to interact with your PagerDuty account.",
       "version": "0.2.1",
-      "updatedAt": "2026-08-25T07:50:54Z",
+      "updatedAt": "2026-09-11T14:19:01Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/PagerDuty/pagerduty-mcp-server#readme",
@@ -24825,13 +25339,13 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.11",
-      "updatedAt": "2026-08-25T07:50:55Z",
+      "updatedAt": "2026-09-11T14:19:02Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
         "repository": "https://github.com/pascalebeier/hitkeep",
         "repositorySource": "github",
-        "stargazerCount": 83,
+        "stargazerCount": 88,
         "websiteUrl": "https://hitkeep.com/use-cases/read-only-mcp-server-web-analytics/"
       }
     },
@@ -24842,7 +25356,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-08-25T07:50:56Z",
+      "updatedAt": "2026-09-11T14:19:04Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -24855,7 +25369,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.SAP:fiori-mcp-server",
       "displayName": "SAP Fiori",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.SAP%2Ffiori-mcp-server/versions/1.11.13",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.SAP%2Ffiori-mcp-server/versions/1.12.4",
       "description": "SAP Fiori - Model Context Protocol (MCP) server",
       "tags": [
         "fiori",
@@ -24863,15 +25377,15 @@
         "fiori-tools",
         "ui5"
       ],
-      "version": "1.11.13",
-      "updatedAt": "2026-08-25T07:50:58Z",
+      "version": "1.12.4",
+      "updatedAt": "2026-09-11T14:19:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SAP/open-ux-tools/tree/HEAD/packages/fiori-mcp-server",
         "repository": "https://github.com/SAP/open-ux-tools",
         "repositorySource": "github",
         "repositorySubfolder": "packages/fiori-mcp-server",
-        "stargazerCount": 155
+        "stargazerCount": 158
       }
     },
     {
@@ -24886,20 +25400,20 @@
         "webcrawler"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:50:59Z",
+      "updatedAt": "2026-09-11T14:19:08Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ScrapeGraphAI/scrapegraph-mcp#readme",
         "repository": "https://github.com/ScrapeGraphAI/scrapegraph-mcp",
         "repositorySource": "github",
-        "stargazerCount": 96
+        "stargazerCount": 110
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Sendmux:sendmux-mcp",
       "displayName": "Email Inbox API + Sending by Sendmux",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Sendmux%2Fsendmux-mcp/versions/1.6.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Sendmux%2Fsendmux-mcp/versions/1.8.0",
       "description": "AI email inbox and sending tools with attachments, search, live events, and webhooks.",
       "tags": [
         "cli",
@@ -24913,15 +25427,15 @@
         "mcp-server",
         "mcp-tools"
       ],
-      "version": "1.6.1",
-      "updatedAt": "2026-08-25T07:51:00Z",
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:09Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
         "repository": "https://github.com/Sendmux/sendmux-sdk",
         "repositorySource": "github",
         "repositorySubfolder": "packages/python/mcp",
-        "stargazerCount": 78,
+        "stargazerCount": 73,
         "websiteUrl": "https://sendmux.ai/docs/guides/mcp"
       }
     },
@@ -24942,20 +25456,20 @@
         "static-analysis"
       ],
       "version": "1.21.0",
-      "updatedAt": "2026-08-25T07:51:01Z",
+      "updatedAt": "2026-09-11T14:19:11Z",
       "metadata": {
         "primaryLanguage": "Java",
         "readmeUrl": "https://github.com/SonarSource/sonarqube-mcp-server#readme",
         "repository": "https://github.com/SonarSource/sonarqube-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 632
+        "stargazerCount": 645
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.UI5:mcp-server",
       "displayName": "UI5",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.UI5%2Fmcp-server/versions/0.2.18",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.UI5%2Fmcp-server/versions/0.2.20",
       "description": "MCP server for SAPUI5/OpenUI5 development",
       "tags": [
         "agenticai",
@@ -24964,14 +25478,14 @@
         "ui5",
         "mcp-server"
       ],
-      "version": "0.2.18",
-      "updatedAt": "2026-08-25T07:51:02Z",
+      "version": "0.2.20",
+      "updatedAt": "2026-09-11T14:19:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/mcp-server#readme",
         "repository": "https://github.com/UI5/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 98
+        "stargazerCount": 99
       }
     },
     {
@@ -24989,7 +25503,7 @@
         "webcomponent"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-08-25T07:51:04Z",
+      "updatedAt": "2026-09-11T14:19:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/webcomponents-mcp-server#readme",
@@ -25002,27 +25516,28 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Vortx-AI:emem",
       "displayName": "emem, the verifiable memory protocol for the physical world",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.2.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Vortx-AI%2Femem/versions/2.4.0",
       "description": "Shared memory for AI agents. One address per fact, one signature you check. No key to read.",
       "tags": [
         "long-term-memory",
-        "world-models",
-        "earth-observation",
-        "long-running-agents",
-        "multi-agent",
         "shared-memory",
-        "substrate",
         "a2a-protocol",
-        "mcp"
+        "mcp",
+        "agent-interoperability",
+        "agent-memory",
+        "ai-agents",
+        "content-addressed",
+        "earth-orientation",
+        "ed25519"
       ],
-      "version": "2.2.0",
-      "updatedAt": "2026-08-25T07:51:05Z",
+      "version": "2.4.0",
+      "updatedAt": "2026-09-11T14:19:15Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
         "repository": "https://github.com/Vortx-AI/emem",
         "repositorySource": "github",
-        "stargazerCount": 54,
+        "stargazerCount": 56,
         "websiteUrl": "https://emem.dev"
       }
     },
@@ -25030,10 +25545,10 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.Wopee-io:wopee-mcp",
       "displayName": "Wopee",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.1",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
-      "version": "1.30.0",
-      "updatedAt": "2026-08-25T07:51:06Z",
+      "version": "1.30.1",
+      "updatedAt": "2026-09-11T14:19:16Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -25056,7 +25571,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-08-25T07:51:07Z",
+      "updatedAt": "2026-09-11T14:19:19Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -25084,12 +25599,12 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-08-25T07:51:08Z",
+      "updatedAt": "2026-09-11T14:19:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
         "repositorySource": "github",
-        "stargazerCount": 12,
+        "stargazerCount": 13,
         "websiteUrl": "https://adkit.so"
       }
     },
@@ -25097,8 +25612,8 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.agentic-hil:agentic-hil",
       "displayName": "Agentic HIL",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.18.0",
-      "description": "Probe, flash, reset and drive UART and CAN on a real STM32 or other embedded target, policy-gated.",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.agentic-hil%2Fagentic-hil/versions/0.21.5",
+      "description": "Develop firmware on the real board behind a debug probe: flash, reset, UART and CAN, policy-gated.",
       "tags": [
         "embedded",
         "hardware-in-the-loop",
@@ -25111,15 +25626,269 @@
         "stlink",
         "ai-agents"
       ],
-      "version": "0.18.0",
-      "updatedAt": "2026-08-25T07:51:09Z",
+      "version": "0.21.5",
+      "updatedAt": "2026-09-11T14:19:21Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
         "repository": "https://github.com/agentic-hil/agentic-hil",
         "repositorySource": "github",
         "stargazerCount": 12,
-        "websiteUrl": "https://github.com/agentic-hil/agentic-hil"
+        "websiteUrl": "https://github.com/agentic-hil/stm32-starter"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.alimbenhelal-pro:alm-xpp-mcp",
+      "displayName": "ALM X++ MCP Server",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.alimbenhelal-pro%2Falm-xpp-mcp/versions/1.5.1",
+      "description": "D365 F&O: 90 AI tools over 200K+ objects, 25M+ cross-refs, 24M+ label translations.",
+      "tags": [
+        "ai",
+        "copilot",
+        "dynamics-365",
+        "erp",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "xpp",
+        "claude-code",
+        "cursor"
+      ],
+      "version": "1.5.1",
+      "updatedAt": "2026-09-11T14:19:23Z",
+      "metadata": {
+        "primaryLanguage": "JavaScript",
+        "readmeUrl": "https://github.com/alimbenhelal-pro/ALM-XPP-MCP#readme",
+        "repository": "https://github.com/alimbenhelal-pro/ALM-XPP-MCP",
+        "repositorySource": "github",
+        "stargazerCount": 2,
+        "websiteUrl": "https://www.almxpp.com"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.anilloutombam:mcp-failure-lab",
+      "displayName": "Anilloutombam MCP Failure Lab",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.anilloutombam%2Fmcp-failure-lab/versions/0.8.0",
+      "description": "A chaos-engineering and resilience-testing toolkit for Model Context Protocol servers.",
+      "tags": [
+        "chaos-engineering",
+        "fault-injection",
+        "mcp-testing",
+        "model-context-protocol",
+        "resilience-testing",
+        "typescript",
+        "cli",
+        "mcp-server"
+      ],
+      "version": "0.8.0",
+      "updatedAt": "2026-09-11T14:19:24Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/anilloutombam/mcp-failure-lab#readme",
+        "repository": "https://github.com/anilloutombam/mcp-failure-lab",
+        "repositorySource": "github"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-aparser",
+      "displayName": "SEO Tools: A-Parser bridge",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-aparser/versions/1.8.0",
+      "description": "Bridge to a self-hosted A-Parser: SERP, suggests and 150+ parsers via its API (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:26Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-ga4",
+      "displayName": "SEO Tools: Google Analytics 4",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-ga4/versions/1.8.0",
+      "description": "Google Analytics 4: reports, traffic sources, landing pages, events, realtime (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:27Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-gsc",
+      "displayName": "SEO Tools: Google Search Console",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-gsc/versions/1.8.0",
+      "description": "Google Search Console: Search Analytics, URL Inspection, sitemaps (read-only, OAuth/service acct).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:28Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-metrika",
+      "displayName": "SEO Tools: Yandex.Metrica",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-metrika/versions/1.8.0",
+      "description": "MCP server for Yandex.Metrica Stat API (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:29Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-wordstat",
+      "displayName": "SEO Tools: Yandex Wordstat",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-wordstat/versions/1.8.0",
+      "description": "MCP server for Yandex Wordstat keyword frequencies (official API v2). Free Yandex Cloud Search API.",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:31Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-xmlriver",
+      "displayName": "SEO Tools: XMLRiver SERP (Google + Yandex)",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-xmlriver/versions/1.8.0",
+      "description": "Google & Yandex SERP, image/news verticals and URL indexation checks via XMLRiver (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:33Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-xmlstock",
+      "displayName": "SEO Tools: XMLStock SERP (Google + Yandex)",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-xmlstock/versions/1.8.0",
+      "description": "Google & Yandex SERP + Yandex Wordstat via XMLStock (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:34Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.antohins:seo-tools-mcp-ywm",
+      "displayName": "SEO Tools: Yandex.Webmaster",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.antohins%2Fseo-tools-mcp-ywm/versions/1.8.0",
+      "description": "MCP server for Yandex.Webmaster search queries (read-only).",
+      "tags": [
+        "claude",
+        "mcp",
+        "model-context-protocol",
+        "search-console",
+        "seo",
+        "yandex"
+      ],
+      "version": "1.8.0",
+      "updatedAt": "2026-09-11T14:19:35Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
+        "repository": "https://github.com/antohins/seo-tools-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3,
+        "websiteUrl": "https://github.com/antohins/seo-tools-mcp#readme"
       }
     },
     {
@@ -25141,7 +25910,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-08-25T07:51:11Z",
+      "updatedAt": "2026-09-11T14:19:37Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -25158,7 +25927,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-08-25T07:51:12Z",
+      "updatedAt": "2026-09-11T14:19:38Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -25172,7 +25941,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.basicmachines-co:basic-memory",
       "displayName": "Basicmachines Co Basic Memory",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.basicmachines-co%2Fbasic-memory/versions/0.23.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.basicmachines-co%2Fbasic-memory/versions/0.23.2",
       "description": "Local-first knowledge management with bi-directional LLM sync via Markdown files.",
       "tags": [
         "ai",
@@ -25186,21 +25955,21 @@
         "knowledge-management",
         "knowlege-graph"
       ],
-      "version": "0.23.0",
-      "updatedAt": "2026-08-25T07:51:13Z",
+      "version": "0.23.2",
+      "updatedAt": "2026-09-11T14:19:39Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
         "repository": "https://github.com/basicmachines-co/basic-memory.git",
         "repositorySource": "github",
-        "stargazerCount": 3752
+        "stargazerCount": 3930
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.brightdata:brightdata-mcp",
       "displayName": "Brightdata",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.brightdata%2Fbrightdata-mcp/versions/2.11.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.brightdata%2Fbrightdata-mcp/versions/2.11.2",
       "description": "Bright Data's Web MCP server enabling AI agents to search, extract & navigate the web",
       "tags": [
         "llm",
@@ -25214,21 +25983,21 @@
         "data-collection",
         "data-extraction"
       ],
-      "version": "2.11.1",
-      "updatedAt": "2026-08-25T07:51:14Z",
+      "version": "2.11.2",
+      "updatedAt": "2026-09-11T14:19:41Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
         "repository": "https://github.com/brightdata/brightdata-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2611
+        "stargazerCount": 2635
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.bytebase:dbhub",
       "displayName": "DBHub",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.bytebase%2Fdbhub/versions/1.2.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.bytebase%2Fdbhub/versions/1.2.3",
       "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB",
       "tags": [
         "ai",
@@ -25242,14 +26011,14 @@
         "postgres",
         "sqlserver"
       ],
-      "version": "1.2.1",
-      "updatedAt": "2026-08-25T07:51:15Z",
+      "version": "1.2.3",
+      "updatedAt": "2026-09-11T14:19:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
         "repository": "https://github.com/bytebase/dbhub",
         "repositorySource": "github",
-        "stargazerCount": 3395
+        "stargazerCount": 3497
       }
     },
     {
@@ -25271,13 +26040,28 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:17Z",
+      "updatedAt": "2026-09-11T14:19:44Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
         "repository": "https://github.com/cap-js/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 109
+        "stargazerCount": 112
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.carterchencc:nomas",
+      "displayName": "Nomas Research",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.carterchencc%2Fnomas/versions/1.3.2",
+      "description": "Parsed SEC events by CIK/CUSIP: 8-K items, Form 144, Form D, FTD. Not EDGAR HTML.",
+      "version": "1.3.2",
+      "updatedAt": "2026-09-11T14:19:45Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/carterchencc/nomas_mcp#readme",
+        "repository": "https://github.com/carterchencc/nomas_mcp",
+        "repositorySource": "github",
+        "websiteUrl": "https://nomas.fyi/research/mcp"
       }
     },
     {
@@ -25299,7 +26083,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:51:18Z",
+      "updatedAt": "2026-09-11T14:19:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -25328,13 +26112,13 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-08-25T07:51:19Z",
+      "updatedAt": "2026-09-11T14:19:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
         "repository": "https://github.com/cometchat/docs-mcp",
         "repositorySource": "github",
-        "stargazerCount": 60,
+        "stargazerCount": 78,
         "websiteUrl": "https://www.cometchat.com/docs/mcp-server"
       }
     },
@@ -25351,16 +26135,19 @@
         "cursor",
         "mcp",
         "windsurf",
-        "gemini-cli-extension"
+        "gemini-cli-extension",
+        "agent",
+        "agentmemory",
+        "context"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-08-25T07:51:20Z",
+      "updatedAt": "2026-09-11T14:19:49Z",
       "metadata": {
-        "primaryLanguage": "TypeScript",
+        "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
         "repository": "https://github.com/contextstream/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 38,
+        "stargazerCount": 43,
         "websiteUrl": "https://contextstream.io/docs/mcp"
       }
     },
@@ -25371,7 +26158,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-08-25T07:51:21Z",
+      "updatedAt": "2026-09-11T14:19:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -25384,7 +26171,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.dsers:dsers-mcp-server",
       "displayName": "DSers Official MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dsers%2Fdsers-mcp-server/versions/1.8.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dsers%2Fdsers-mcp-server/versions/1.8.4",
       "description": "Official DSers MCP for dropshipping: import, edit, price, and publish products to Shopify and Wix.",
       "tags": [
         "1688",
@@ -25398,49 +26185,32 @@
         "mcp",
         "model-context-protocol"
       ],
-      "version": "1.8.3",
-      "updatedAt": "2026-08-25T07:51:22Z",
+      "version": "1.8.4",
+      "updatedAt": "2026-09-11T14:19:53Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 7,
+        "stargazerCount": 9,
         "websiteUrl": "https://www.dsers.com"
-      }
-    },
-    {
-      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.dynatrace-oss:Dynatrace-mcp",
-      "displayName": "Dynatrace",
-      "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2FDynatrace-mcp/versions/2.1.2",
-      "description": "[DEPRECATED] Dynatrace MCP Server. Migrate to dynatrace-for-ai or Dynatrace Remote MCP Server.",
-      "tags": [
-        "claude",
-        "cline",
-        "dynatrace",
-        "mcp",
-        "monitoring",
-        "observability",
-        "copilot"
-      ],
-      "version": "2.1.2",
-      "updatedAt": "2026-08-25T07:51:23Z",
-      "metadata": {
-        "primaryLanguage": "TypeScript",
-        "readmeUrl": "https://github.com/dynatrace-oss/Dynatrace-mcp#readme",
-        "repository": "https://github.com/dynatrace-oss/Dynatrace-mcp",
-        "repositorySource": "github",
-        "stargazerCount": 134
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.dynatrace-oss:dynatrace-managed-mcp",
       "displayName": "Dynatrace Managed",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2Fdynatrace-managed-mcp/versions/1.0.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.dynatrace-oss%2Fdynatrace-managed-mcp/versions/1.1.1",
       "description": "MCP server for Dynatrace Managed to access logs, events, and metrics.",
-      "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:51:25Z",
+      "tags": [
+        "dynatrace",
+        "managed",
+        "mcp",
+        "mcp-server",
+        "monitoring",
+        "observability"
+      ],
+      "version": "1.1.1",
+      "updatedAt": "2026-09-11T14:19:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -25456,13 +26226,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-08-25T07:51:26Z",
+      "updatedAt": "2026-09-11T14:19:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
         "repository": "https://github.com/f/prompts.chat-mcp",
         "repositorySource": "github",
-        "stargazerCount": 33
+        "stargazerCount": 34
       }
     },
     {
@@ -25472,7 +26242,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-08-25T07:51:27Z",
+      "updatedAt": "2026-09-11T14:19:57Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -25492,35 +26262,35 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-08-25T07:51:28Z",
+      "updatedAt": "2026-09-11T14:19:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
         "repository": "https://github.com/getsentry/sentry-mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server",
-        "stargazerCount": 828
+        "stargazerCount": 846
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.github:github-mcp-server",
       "displayName": "GitHub",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.github%2Fgithub-mcp-server/versions/1.10.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.github%2Fgithub-mcp-server/versions/1.12.1",
       "description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language.",
       "tags": [
         "github",
         "mcp",
         "mcp-server"
       ],
-      "version": "1.10.1",
-      "updatedAt": "2026-08-25T07:51:29Z",
+      "version": "1.12.1",
+      "updatedAt": "2026-09-11T14:20:00Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32486
+        "stargazerCount": 32869
       }
     },
     {
@@ -25535,7 +26305,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-08-25T07:51:31Z",
+      "updatedAt": "2026-09-11T14:20:02Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -25551,13 +26321,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:32Z",
+      "updatedAt": "2026-09-11T14:20:04Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
         "repository": "https://github.com/hashicorp/terraform-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1512
+        "stargazerCount": 1527
       }
     },
     {
@@ -25579,7 +26349,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:51:33Z",
+      "updatedAt": "2026-09-11T14:20:05Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -25592,7 +26362,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.hostinger:hostinger-api-mcp",
       "displayName": "Hostinger API",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.47.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.hostinger%2Fhostinger-api-mcp/versions/1.59.0",
       "description": "MCP server for Hostinger API",
       "tags": [
         "ai",
@@ -25603,21 +26373,21 @@
         "mcp",
         "gemini-cli-extension"
       ],
-      "version": "1.47.0",
-      "updatedAt": "2026-08-25T07:51:34Z",
+      "version": "1.59.0",
+      "updatedAt": "2026-09-11T14:20:07Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
         "repository": "https://github.com/hostinger/api-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 142
+        "stargazerCount": 151
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.ihor-sokoliuk:mcp-searxng",
       "displayName": "SearXNG Search",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/2.0.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.ihor-sokoliuk%2Fmcp-searxng/versions/2.2.0",
       "description": "MCP server for SearXNG — privacy-respecting web search with pagination, URL reading",
       "tags": [
         "ai",
@@ -25631,21 +26401,21 @@
         "cursor",
         "privacy"
       ],
-      "version": "2.0.0",
-      "updatedAt": "2026-08-25T07:51:36Z",
+      "version": "2.2.0",
+      "updatedAt": "2026-09-11T14:20:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
         "repository": "https://github.com/ihor-sokoliuk/mcp-searxng",
         "repositorySource": "github",
-        "stargazerCount": 1158
+        "stargazerCount": 1221
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.jagoff:memo",
       "displayName": "memo",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.13.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.jagoff%2Fmemo/versions/4.16.0",
       "description": "Memory for AI agents — MLX (Apple Silicon) or CPU (Linux), sqlite-vec + BM25, zero cloud.",
       "tags": [
         "apple-silicon",
@@ -25659,14 +26429,14 @@
         "qwen",
         "rag"
       ],
-      "version": "4.13.3",
-      "updatedAt": "2026-08-25T07:51:37Z",
+      "version": "4.16.0",
+      "updatedAt": "2026-09-11T14:20:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
         "repository": "https://github.com/jagoff/memo",
         "repositorySource": "github",
-        "stargazerCount": 14
+        "stargazerCount": 18
       }
     },
     {
@@ -25687,7 +26457,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:51:39Z",
+      "updatedAt": "2026-09-11T14:20:15Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -25702,7 +26472,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.1",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.1",
-      "updatedAt": "2026-08-25T07:51:40Z",
+      "updatedAt": "2026-09-11T14:20:17Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -25718,13 +26488,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-08-25T07:51:41Z",
+      "updatedAt": "2026-09-11T14:20:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
         "repository": "https://github.com/mapbox/mcp-devkit-server",
         "repositorySource": "github",
-        "stargazerCount": 59
+        "stargazerCount": 60
       }
     },
     {
@@ -25734,13 +26504,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-08-25T07:51:42Z",
+      "updatedAt": "2026-09-11T14:20:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
         "repository": "https://github.com/mapbox/mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 352
+        "stargazerCount": 354
       }
     },
     {
@@ -25750,19 +26520,19 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:43Z",
+      "updatedAt": "2026-09-11T14:20:21Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
         "repositorySource": "github",
-        "stargazerCount": 49
+        "stargazerCount": 53
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.microsoft:awesome-copilot",
       "displayName": "Awesome Copilot MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026082505",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2Fawesome-copilot/versions/1.0.2026090704",
       "description": "An MCP server that stores Copilot customizations from the Awesome Copilot repository",
       "tags": [
         "dotnet",
@@ -25770,8 +26540,8 @@
         "mcp-client",
         "mcp-server"
       ],
-      "version": "1.0.2026082505",
-      "updatedAt": "2026-08-25T07:51:45Z",
+      "version": "1.0.2026090704",
+      "updatedAt": "2026-09-11T14:20:24Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -25788,20 +26558,20 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:51:47Z",
+      "updatedAt": "2026-09-11T14:20:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
         "repository": "https://github.com/miroapp/miro-ai",
         "repositorySource": "github",
-        "stargazerCount": 149
+        "stargazerCount": 151
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.mlava:agent-ready-mcp",
       "displayName": "Agent Ready",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fagent-ready-mcp/versions/0.7.5",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fagent-ready-mcp/versions/0.7.7",
       "description": "Scan any URL for AI agent readability — Vercel Spec, llmstxt.org, and agent-protocol manifests.",
       "tags": [
         "a2a",
@@ -25815,8 +26585,8 @@
         "mcp",
         "mcp-server-card"
       ],
-      "version": "0.7.5",
-      "updatedAt": "2026-08-25T07:51:48Z",
+      "version": "0.7.7",
+      "updatedAt": "2026-09-11T14:20:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -25830,7 +26600,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.mlava:scholar-sidekick-mcp",
       "displayName": "Scholar Sidekick",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fscholar-sidekick-mcp/versions/0.8.8",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.mlava%2Fscholar-sidekick-mcp/versions/0.8.11",
       "description": "Catch AI-fabricated citations (real DOI + fake title). Retraction, open-access, 10,000+ CSL styles.",
       "tags": [
         "academic",
@@ -25844,14 +26614,14 @@
         "doi",
         "mcp"
       ],
-      "version": "0.8.8",
-      "updatedAt": "2026-08-25T07:51:49Z",
+      "version": "0.8.11",
+      "updatedAt": "2026-09-11T14:20:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
         "repository": "https://github.com/mlava/scholar-sidekick-mcp",
         "repositorySource": "github",
-        "stargazerCount": 8,
+        "stargazerCount": 9,
         "websiteUrl": "https://scholar-sidekick.com/mcp"
       }
     },
@@ -25869,13 +26639,13 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-08-25T07:51:50Z",
+      "updatedAt": "2026-09-11T14:20:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
         "repository": "https://github.com/mongodb-js/mongodb-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 1106
+        "stargazerCount": 1126
       }
     },
     {
@@ -25897,14 +26667,14 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-08-25T07:51:51Z",
+      "updatedAt": "2026-09-11T14:20:35Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
         "repository": "https://github.com/netdata/netdata",
         "repositorySource": "github",
         "repositorySubfolder": "docs/netdata-ai/mcp",
-        "stargazerCount": 80285,
+        "stargazerCount": 80484,
         "websiteUrl": "https://www.netdata.cloud"
       }
     },
@@ -25915,7 +26685,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:52Z",
+      "updatedAt": "2026-09-11T14:20:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -25943,13 +26713,13 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:51:53Z",
+      "updatedAt": "2026-09-11T14:20:38Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
         "repository": "https://github.com/oleksiijko/pmb",
         "repositorySource": "github",
-        "stargazerCount": 297
+        "stargazerCount": 278
       }
     },
     {
@@ -25971,29 +26741,70 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:51:55Z",
+      "updatedAt": "2026-09-11T14:20:39Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
         "repository": "https://github.com/openaccountants/openaccountants",
         "repositorySource": "github",
-        "stargazerCount": 342
+        "stargazerCount": 371
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.opsloft:tariff-resolver",
+      "displayName": "Opsloft Tariff Resolver",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.opsloft%2Ftariff-resolver/versions/1.1.0",
+      "description": "US import duty research: HTS codes, Chapter 99 duties, MPF/HMF fees, landed cost. USITC data.",
+      "tags": [
+        "ai",
+        "customs",
+        "hts",
+        "import-duty",
+        "landed-cost",
+        "llm",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "section-301"
+      ],
+      "version": "1.1.0",
+      "updatedAt": "2026-09-11T14:20:41Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/opsloft/tariff-resolver#readme",
+        "repository": "https://github.com/opsloft/tariff-resolver",
+        "repositorySource": "github",
+        "stargazerCount": 2,
+        "websiteUrl": "https://opsloft.dev"
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.opus-pro:opusclip",
       "displayName": "OpusClip",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.2.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.opus-pro%2Fopusclip/versions/0.3.0",
       "description": "Turn long videos into AI-curated short clips: caption, reframe, thumbnail, schedule, and publish.",
-      "version": "0.2.0",
-      "updatedAt": "2026-08-25T07:51:56Z",
+      "tags": [
+        "agentic-ai",
+        "ai-agents",
+        "claude",
+        "claude-code",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "openclaw",
+        "short-form-video",
+        "video-editing"
+      ],
+      "version": "0.3.0",
+      "updatedAt": "2026-09-11T14:20:42Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
         "repository": "https://github.com/opus-pro/opusclip-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2,
+        "stargazerCount": 3,
         "websiteUrl": "https://help.opus.pro/api-reference/agent-setup"
       }
     },
@@ -26004,7 +26815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-08-25T07:51:57Z",
+      "updatedAt": "2026-09-11T14:20:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -26017,16 +26828,16 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.patrickchugh:terravision",
       "displayName": "TerraVision",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.46.4",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.47.0",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
-      "version": "0.46.4",
-      "updatedAt": "2026-08-25T07:51:58Z",
+      "version": "0.47.0",
+      "updatedAt": "2026-09-11T14:20:45Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
         "repository": "https://github.com/patrickchugh/terravision",
         "repositorySource": "github",
-        "stargazerCount": 1615,
+        "stargazerCount": 1629,
         "websiteUrl": "https://patrickchugh.github.io/terravision/"
       }
     },
@@ -26034,7 +26845,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.pete-builds:unifi",
       "displayName": "UniFi Gateway",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.pete-builds%2Funifi/versions/0.21.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.pete-builds%2Funifi/versions/0.21.2",
       "description": "Safe-by-default UniFi MCP: Network + Protect + Access, multi-site, dry-run, audit log.",
       "tags": [
         "docker",
@@ -26048,14 +26859,14 @@
         "unifi",
         "ucg-fiber"
       ],
-      "version": "0.21.1",
-      "updatedAt": "2026-08-25T07:51:59Z",
+      "version": "0.21.2",
+      "updatedAt": "2026-09-11T14:20:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
         "repository": "https://github.com/pete-builds/mcp-unifi",
         "repositorySource": "github",
-        "stargazerCount": 20,
+        "stargazerCount": 22,
         "websiteUrl": "https://pete-builds.github.io/mcp-unifi/"
       }
     },
@@ -26074,13 +26885,13 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:52:00Z",
+      "updatedAt": "2026-09-11T14:20:48Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
         "repository": "https://github.com/pgEdge/pgedge-postgres-mcp",
         "repositorySource": "github",
-        "stargazerCount": 219
+        "stargazerCount": 223
       }
     },
     {
@@ -26102,7 +26913,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:52:01Z",
+      "updatedAt": "2026-09-11T14:20:49Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -26126,13 +26937,13 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-08-25T07:52:03Z",
+      "updatedAt": "2026-09-11T14:20:50Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
         "repository": "https://github.com/pubnub/pubnub-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32,
+        "stargazerCount": 33,
         "websiteUrl": "https://www.pubnub.com/networking-mcp-server"
       }
     },
@@ -26143,13 +26954,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:04Z",
+      "updatedAt": "2026-09-11T14:20:52Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
         "repository": "https://github.com/quicknode/agent-plugins",
         "repositorySource": "github",
-        "stargazerCount": 4
+        "stargazerCount": 5
       }
     },
     {
@@ -26171,13 +26982,13 @@
         "mcp"
       ],
       "version": "6.0.0",
-      "updatedAt": "2026-08-25T07:52:05Z",
+      "updatedAt": "2026-09-11T14:20:53Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
         "repository": "https://github.com/rigour-labs/rigour",
         "repositorySource": "github",
-        "stargazerCount": 26
+        "stargazerCount": 27
       }
     },
     {
@@ -26187,7 +26998,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:52:06Z",
+      "updatedAt": "2026-09-11T14:20:56Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -26200,72 +27011,96 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.sassoftware:sas-mcp-server",
       "displayName": "SAS Viya",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.sassoftware%2Fsas-mcp-server/versions/1.11.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.sassoftware%2Fsas-mcp-server/versions/1.14.2",
       "description": "Execute SAS code and query Compute, CAS, and model APIs on SAS Viya via OAuth 2.0.",
       "tags": [
         "sas-aiml",
         "sas-osp"
       ],
-      "version": "1.11.1",
-      "updatedAt": "2026-08-25T07:52:07Z",
+      "version": "1.14.2",
+      "updatedAt": "2026-09-11T14:20:57Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
         "repository": "https://github.com/sassoftware/sas-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 52
+        "stargazerCount": 54
       }
     },
     {
-      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.satohubai:onchain-agents",
-      "displayName": "Sato Hub: Onchain Agents",
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.scavio-ai:scavio-mcp",
+      "displayName": "Scavio",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.satohubai%2Fonchain-agents/versions/1.0.0",
-      "description": "Search scored onchain agent frameworks, MCPs, wallets, tools, and live agents.",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.scavio-ai%2Fscavio-mcp/versions/0.14.1",
+      "description": "Structured web data from 31 platforms: Google, YouTube, Amazon, Walmart, Reddit, TikTok, LinkedIn",
       "tags": [
-        "ai-agents",
-        "awesome-list",
-        "base",
-        "crypto",
-        "erc-8004",
-        "ethereum",
+        "ai",
+        "amazon",
+        "claude",
+        "cursor",
+        "google-search",
         "mcp",
-        "onchain-agents",
-        "web3",
-        "x402"
+        "mcp-server",
+        "model-context-protocol",
+        "search-api",
+        "tiktok"
       ],
-      "version": "1.0.0",
-      "updatedAt": "2026-08-25T07:52:09Z",
+      "version": "0.14.1",
+      "updatedAt": "2026-09-11T14:20:59Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
-        "readmeUrl": "https://github.com/satohubai/onchain-agents#readme",
-        "repository": "https://github.com/satohubai/onchain-agents",
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/scavio-ai/scavio-mcp#readme",
+        "repository": "https://github.com/scavio-ai/scavio-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1,
-        "websiteUrl": "https://satohub.ai/mcp"
+        "stargazerCount": 7
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.serpapi:serpapi-mcp",
-      "displayName": "Serpapi",
+      "displayName": "SerpApi",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.1",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.3",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
-      "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:10Z",
+      "version": "1.0.3",
+      "updatedAt": "2026-09-11T14:21:01Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
         "repository": "https://github.com/serpapi/serpapi-mcp",
         "repositorySource": "github",
-        "stargazerCount": 166
+        "stargazerCount": 169,
+        "websiteUrl": "https://serpapi.com/"
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.shariqriazz:google-ai-search-mcp",
+      "displayName": "Google AI Search MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.shariqriazz%2Fgoogle-ai-search-mcp/versions/1.1.1",
+      "description": "Google AI search and documentation tools for MCP clients using Vertex AI or the Gemini API.",
+      "tags": [
+        "gemini",
+        "google-ai",
+        "mcp",
+        "model-context-protocol",
+        "search",
+        "typescript"
+      ],
+      "version": "1.1.1",
+      "updatedAt": "2026-09-11T14:21:02Z",
+      "metadata": {
+        "primaryLanguage": "TypeScript",
+        "readmeUrl": "https://github.com/shariqriazz/google-ai-search-mcp#readme",
+        "repository": "https://github.com/shariqriazz/google-ai-search-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 6
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.smaniches:semantic-scholar-mcp",
       "displayName": "Semantic Scholar MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.smaniches%2Fsemantic-scholar-mcp/versions/1.7.3",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.smaniches%2Fsemantic-scholar-mcp/versions/1.7.4",
       "description": "MCP server for the Semantic Scholar API: search 200M+ papers, citations, authors, recommendations.",
       "tags": [
         "academic-tool",
@@ -26279,14 +27114,42 @@
         "model-context-protocol",
         "semantic-scholar"
       ],
-      "version": "1.7.3",
-      "updatedAt": "2026-08-25T07:52:11Z",
+      "version": "1.7.4",
+      "updatedAt": "2026-09-11T14:21:06Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
         "repository": "https://github.com/smaniches/semantic-scholar-mcp",
         "repositorySource": "github",
-        "stargazerCount": 14
+        "stargazerCount": 21
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.smaniches:uniprot-mcp",
+      "displayName": "UniProt MCP",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.smaniches%2Funiprot-mcp/versions/1.3.6",
+      "description": "Verifiable, release-aware protein evidence workflows over UniProt and linked scientific sources.",
+      "tags": [
+        "bioinformatics",
+        "claude",
+        "claude-ai",
+        "claude-code",
+        "clinvar-database",
+        "clinvar-database-mcp",
+        "drug",
+        "drug-design",
+        "drug-discovery",
+        "drug-repurposing"
+      ],
+      "version": "1.3.6",
+      "updatedAt": "2026-09-11T14:21:07Z",
+      "metadata": {
+        "primaryLanguage": "Python",
+        "readmeUrl": "https://github.com/smaniches/uniprot-mcp#readme",
+        "repository": "https://github.com/smaniches/uniprot-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 3
       }
     },
     {
@@ -26296,7 +27159,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-08-25T07:52:12Z",
+      "updatedAt": "2026-09-11T14:21:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -26313,13 +27176,13 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-08-25T07:52:13Z",
+      "updatedAt": "2026-09-11T14:21:10Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
         "repository": "https://github.com/snyk/saw-mcp",
         "repositorySource": "github",
-        "stargazerCount": 7
+        "stargazerCount": 8
       }
     },
     {
@@ -26329,7 +27192,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-08-25T07:52:14Z",
+      "updatedAt": "2026-09-11T14:21:11Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -26341,7 +27204,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.stackql:stackql-mcp",
       "displayName": "StackQL MCP Server",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.stackql%2Fstackql-mcp/versions/0.10.605",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.stackql%2Fstackql-mcp/versions/0.11.669",
       "description": "SQL-native query and provisioning engine for cloud infrastructure, served over MCP.",
       "tags": [
         "asset-management",
@@ -26355,14 +27218,14 @@
         "sql",
         "stackql"
       ],
-      "version": "0.10.605",
-      "updatedAt": "2026-08-25T07:52:15Z",
+      "version": "0.11.669",
+      "updatedAt": "2026-09-11T14:21:12Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
         "repository": "https://github.com/stackql/stackql",
         "repositorySource": "github",
-        "stargazerCount": 874,
+        "stargazerCount": 958,
         "websiteUrl": "https://stackql.io"
       }
     },
@@ -26381,7 +27244,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:16Z",
+      "updatedAt": "2026-09-11T14:21:13Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -26398,41 +27261,41 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-08-25T07:52:17Z",
+      "updatedAt": "2026-09-11T14:21:14Z",
       "metadata": {
-        "primaryLanguage": "JavaScript",
+        "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
         "repository": "https://github.com/tavily-ai/tavily-mcp",
         "repositorySource": "github",
-        "stargazerCount": 2352
+        "stargazerCount": 2378
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.uizze:uizze",
       "displayName": "Uizze",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.uizze%2Fuizze/versions/3.0.0",
-      "description": "Focused full-screen UI references and hosted design materials for coding agents.",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.uizze%2Fuizze/versions/3.0.2",
+      "description": "UI design that stands out. Full-screen UI references and design materials for coding agents.",
       "tags": [
         "agent-skills",
         "claude-code",
         "codex",
         "cursor",
-        "frontend",
         "ios-design",
         "ui-design",
         "design-systems",
         "web-design",
-        "anti-ui-slop"
+        "anti-ui-slop",
+        "ai-agents"
       ],
-      "version": "3.0.0",
-      "updatedAt": "2026-08-25T07:52:18Z",
+      "version": "3.0.2",
+      "updatedAt": "2026-09-11T14:21:16Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
         "repository": "https://github.com/uizze/uizze",
         "repositorySource": "github",
-        "stargazerCount": 11,
+        "stargazerCount": 19,
         "websiteUrl": "https://uizze.com"
       }
     },
@@ -26440,7 +27303,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.upstash:context7",
       "displayName": "Context7",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.upstash%2Fcontext7/versions/1.0.31",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.upstash%2Fcontext7/versions/4.1.0",
       "description": "Up-to-date code docs for any prompt",
       "tags": [
         "llm",
@@ -26448,14 +27311,15 @@
         "mcp-server",
         "vibe-coding"
       ],
-      "version": "1.0.31",
-      "updatedAt": "2026-08-25T07:52:19Z",
+      "version": "4.1.0",
+      "updatedAt": "2026-09-11T14:21:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
         "repository": "https://github.com/upstash/context7",
         "repositorySource": "github",
-        "stargazerCount": 61180
+        "stargazerCount": 61882,
+        "websiteUrl": "https://context7.com"
       }
     },
     {
@@ -26465,7 +27329,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-08-25T07:52:20Z",
+      "updatedAt": "2026-09-11T14:21:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -26488,13 +27352,13 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-08-25T07:52:22Z",
+      "updatedAt": "2026-09-11T14:21:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
         "repository": "https://github.com/vercel/next-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 811
+        "stargazerCount": 819
       }
     },
     {
@@ -26516,12 +27380,12 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-08-25T07:52:23Z",
+      "updatedAt": "2026-09-11T14:21:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
         "repositorySource": "github",
-        "stargazerCount": 1232,
+        "stargazerCount": 1222,
         "websiteUrl": "https://docs.vybenetwork.com/docs/mcp"
       }
     },
@@ -26529,7 +27393,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.wonderwhy-er:desktop-commander",
       "displayName": "Desktop Commander",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.wonderwhy-er%2Fdesktop-commander/versions/0.2.47",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.wonderwhy-er%2Fdesktop-commander/versions/0.2.50",
       "description": "MCP server for terminal commands, file operations, and process management",
       "tags": [
         "agent",
@@ -26542,14 +27406,14 @@
         "vibe-coding",
         "gemini-cli-extension"
       ],
-      "version": "0.2.47",
-      "updatedAt": "2026-08-25T07:52:24Z",
+      "version": "0.2.50",
+      "updatedAt": "2026-09-11T14:21:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
         "repository": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
         "repositorySource": "github",
-        "stargazerCount": 9389
+        "stargazerCount": 9540
       }
     },
     {
@@ -26562,7 +27426,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-08-25T07:52:25Z",
+      "updatedAt": "2026-09-11T14:21:50Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -26575,16 +27439,16 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.zereight:gitlab-mcp",
       "displayName": "Zereight Gitlab",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.52",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.61",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
-      "version": "2.1.52",
-      "updatedAt": "2026-08-25T07:52:26Z",
+      "version": "2.1.61",
+      "updatedAt": "2026-09-11T14:22:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
         "repository": "https://github.com/zereight/gitlab-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1920
+        "stargazerCount": 1968
       }
     },
     {
@@ -26606,13 +27470,13 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-08-25T07:52:28Z",
+      "updatedAt": "2026-09-11T14:22:10Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
         "repository": "https://github.com/zscaler/zscaler-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 46,
+        "stargazerCount": 50,
         "websiteUrl": "https://github.com/zscaler/zscaler-mcp-server"
       }
     },
@@ -26622,8 +27486,18 @@
       "type": "application/mcp-server+json",
       "url": "https://api.mcp.github.com/v0.1/servers/io.mediawork%2Fmediawork/versions/0.1.1",
       "description": "Search Mediawork's directory of post-production and distribution vendors, plus FAQ and plans.",
+      "tags": [
+        "film-tv",
+        "mcp",
+        "mcp-server",
+        "media-production",
+        "model-context-protocol",
+        "nextjs",
+        "post-production",
+        "typescript"
+      ],
       "version": "0.1.1",
-      "updatedAt": "2026-08-25T07:52:29Z",
+      "updatedAt": "2026-09-11T14:22:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -26651,7 +27525,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-08-25T07:52:30Z",
+      "updatedAt": "2026-09-11T14:22:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -26667,7 +27541,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-08-25T07:52:31Z",
+      "updatedAt": "2026-09-11T14:22:15Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -26682,7 +27556,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-08-25T07:52:32Z",
+      "updatedAt": "2026-09-11T14:22:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -26703,13 +27577,13 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-08-25T07:52:33Z",
+      "updatedAt": "2026-09-11T14:22:19Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
         "repository": "https://github.com/snyk/studio-mcp",
         "repositorySource": "github",
-        "stargazerCount": 54
+        "stargazerCount": 55
       }
     },
     {
@@ -26719,7 +27593,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-08-25T07:52:34Z",
+      "updatedAt": "2026-09-11T14:22:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -26764,7 +27638,31 @@
         "readmeUrl": "https://github.com/makenotion/notion-mcp-server#readme",
         "repository": "https://github.com/makenotion/notion-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4603
+        "stargazerCount": 4625
+      }
+    },
+    {
+      "identifier": "urn:air:registry.modelcontextprotocol.io:me.speedof:speed-test",
+      "displayName": "SpeedOf.Me",
+      "type": "application/mcp-server+json",
+      "url": "https://api.mcp.github.com/v0.1/servers/me.speedof%2Fspeed-test/versions/1.1.3",
+      "description": "Official SpeedOf.Me server - Accurate speed tests via over 130 global edge servers with analytics.",
+      "tags": [
+        "ai-agents",
+        "internet-speed-test",
+        "mcp",
+        "mcp-server",
+        "model-context-protocol",
+        "speedtest"
+      ],
+      "version": "1.1.3",
+      "updatedAt": "2026-09-11T14:22:25Z",
+      "metadata": {
+        "readmeUrl": "https://github.com/SpeedOfMe/speedofme-mcp#readme",
+        "repository": "https://github.com/SpeedOfMe/speedofme-mcp",
+        "repositorySource": "github",
+        "stargazerCount": 1,
+        "websiteUrl": "https://speedof.me/api"
       }
     },
     {
@@ -26780,7 +27678,7 @@
         "readmeUrl": "https://github.com/microsoft/azure-devops-mcp#readme",
         "repository": "https://github.com/microsoft/azure-devops-mcp",
         "repositorySource": "github",
-        "stargazerCount": 1978
+        "stargazerCount": 2010
       }
     },
     {
@@ -26800,7 +27698,7 @@
         "readmeUrl": "https://github.com/microsoft/clarity-mcp-server#readme",
         "repository": "https://github.com/microsoft/clarity-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 110
+        "stargazerCount": 115
       }
     },
     {
@@ -26815,7 +27713,7 @@
         "readmeUrl": "https://github.com/microsoft/devbox-mcp-server#readme",
         "repository": "https://github.com/microsoft/devbox-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 12
+        "stargazerCount": 13
       }
     },
     {
@@ -26831,7 +27729,7 @@
         "readmeUrl": "https://github.com/microsoft/fabric-rti-mcp#readme",
         "repository": "https://github.com/microsoft/fabric-rti-mcp",
         "repositorySource": "github",
-        "stargazerCount": 129
+        "stargazerCount": 130
       }
     },
     {
@@ -26856,7 +27754,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 176100
+        "stargazerCount": 182601
       }
     },
     {
@@ -26876,7 +27774,7 @@
         "readmeUrl": "https://github.com/microsoft/playwright-mcp#readme",
         "repository": "https://github.com/microsoft/playwright-mcp",
         "repositorySource": "github",
-        "stargazerCount": 36442
+        "stargazerCount": 37010
       }
     },
     {
@@ -26904,7 +27802,7 @@
         "readmeUrl": "https://github.com/microsoftdocs/mcp#readme",
         "repository": "https://github.com/microsoftdocs/mcp",
         "repositorySource": "github",
-        "stargazerCount": 1858
+        "stargazerCount": 1884
       }
     },
     {
@@ -26920,7 +27818,7 @@
         "readmeUrl": "https://github.com/neondatabase/mcp-server-neon#readme",
         "repository": "https://github.com/neondatabase/mcp-server-neon",
         "repositorySource": "github",
-        "stargazerCount": 624
+        "stargazerCount": 637
       }
     },
     {
@@ -26963,13 +27861,13 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-08-25T07:52:35Z",
+      "updatedAt": "2026-09-11T14:22:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
         "repository": "https://github.com/Wolfe-Jam/claude-faf-mcp",
         "repositorySource": "github",
-        "stargazerCount": 22,
+        "stargazerCount": 23,
         "websiteUrl": "https://faf.one"
       }
     },
@@ -26977,8 +27875,8 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:one.faf:faf-mcp",
       "displayName": ".FAF Context",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/one.faf%2Ffaf-mcp/versions/2.3.1",
-      "description": "Dedicated IDE Edition. Persistent project context for Cursor, Windsurf, Cline, VS Code.",
+      "url": "https://api.mcp.github.com/v0.1/servers/one.faf%2Ffaf-mcp/versions/3.0.2",
+      "description": ".FAF Context — persistent project context for Cursor, VS Code and every MCP-compatible IDE.",
       "tags": [
         "ai",
         "ai-context",
@@ -26991,14 +27889,14 @@
         "project-dna",
         "typescript"
       ],
-      "version": "2.3.1",
-      "updatedAt": "2026-08-25T07:52:37Z",
+      "version": "3.0.2",
+      "updatedAt": "2026-09-11T14:22:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
         "repository": "https://github.com/Wolfe-Jam/faf-mcp",
         "repositorySource": "github",
-        "stargazerCount": 6,
+        "stargazerCount": 7,
         "websiteUrl": "https://faf.one"
       }
     },
@@ -27027,14 +27925,14 @@
         "readmeUrl": "https://github.com/oraios/serena#readme",
         "repository": "https://github.com/oraios/serena",
         "repositorySource": "github",
-        "stargazerCount": 28470
+        "stargazerCount": 29180
       }
     },
     {
       "identifier": "urn:air:registry.modelcontextprotocol.io:org.sylin:ghostlight",
       "displayName": "Sylin Ghostlight",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/0.8.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/org.sylin%2Fghostlight/versions/1.3.5",
       "description": "Visible local browser automation in signed-in Chromium, with optional policy and audit.",
       "tags": [
         "access-control",
@@ -27048,8 +27946,8 @@
         "model-context-protocol",
         "rust"
       ],
-      "version": "0.8.0",
-      "updatedAt": "2026-08-25T07:52:38Z",
+      "version": "1.3.5",
+      "updatedAt": "2026-09-11T14:22:43Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -27078,7 +27976,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:39Z",
+      "updatedAt": "2026-09-11T14:22:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -27127,7 +28025,7 @@
         "readmeUrl": "https://github.com/sunriseapps/imagesorcery-mcp#readme",
         "repository": "https://github.com/sunriseapps/imagesorcery-mcp",
         "repositorySource": "github",
-        "stargazerCount": 326
+        "stargazerCount": 330
       }
     },
     {
@@ -27137,7 +28035,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-08-25T07:52:40Z",
+      "updatedAt": "2026-09-11T14:22:49Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",
@@ -27170,7 +28068,7 @@
         "readmeUrl": "https://github.com/zapier/zapier-mcp#readme",
         "repository": "https://github.com/zapier/zapier-mcp",
         "repositorySource": "github",
-        "stargazerCount": 388
+        "stargazerCount": 405
       }
     }
   ]

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -22466,7 +22466,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:15:01Z",
+      "updatedAt": "2026-09-11T17:38:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/bittlebitsai/bittlebits-plugin#readme",
         "repository": "https://github.com/bittlebitsai/bittlebits-plugin",
@@ -22478,10 +22478,10 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:ai.bowmark:bowmark",
       "displayName": "Bowmark",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/ai.bowmark%2Fbowmark/versions/8.112.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/ai.bowmark%2Fbowmark/versions/8.113.1",
       "description": "Do things on live websites: prices, availability, quotes, bookings, anything behind a form or login.",
-      "version": "8.112.0",
-      "updatedAt": "2026-09-11T14:15:13Z",
+      "version": "8.113.1",
+      "updatedAt": "2026-09-11T17:38:56Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/bowmark-ai/skill#readme",
@@ -22497,7 +22497,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.certscore%2Fmcp-light/versions/0.2.20",
       "description": "Free website privacy scanner for pre-consent cookies, trackers, consent, policy, and HTTPS/TLS.",
       "version": "0.2.20",
-      "updatedAt": "2026-09-11T14:15:28Z",
+      "updatedAt": "2026-09-11T17:39:11Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ergoveritas1-alt/certscore.ai/tree/HEAD/packages/certscore-mcp",
@@ -22514,7 +22514,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.connectmachine%2Fconnectmachine/versions/1.0.8",
       "description": "Manage your ConnectMachine contacts, networks, events, and digital business cards.",
       "version": "1.0.8",
-      "updatedAt": "2026-09-11T14:15:30Z",
+      "updatedAt": "2026-09-11T17:39:12Z",
       "metadata": {
         "readmeUrl": "https://github.com/connectmachine/mcp-server#readme",
         "repository": "https://github.com/connectmachine/mcp-server",
@@ -22539,7 +22539,7 @@
         "medianeria"
       ],
       "version": "1.0.4",
-      "updatedAt": "2026-09-11T14:15:37Z",
+      "updatedAt": "2026-09-11T17:39:13Z",
       "metadata": {
         "readmeUrl": "https://github.com/CMS87/epinu-mcp#readme",
         "repository": "https://github.com/CMS87/epinu-mcp",
@@ -22554,7 +22554,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/ai.example4%2Fxmp4/versions/1.2.6",
       "description": "OSS libs in your stack, really used: source, tests, callers. C#, Java, TS, Python, Rust, PHP+.",
       "version": "1.2.6",
-      "updatedAt": "2026-09-11T14:15:39Z",
+      "updatedAt": "2026-09-11T17:39:14Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/0ics-srls/lsai-xmp4.public#readme",
@@ -22578,7 +22578,7 @@
         "web-search"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-09-11T14:15:40Z",
+      "updatedAt": "2026-09-11T17:39:16Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/keenableai/keenable-mcp#readme",
@@ -22605,7 +22605,7 @@
         "claude-code"
       ],
       "version": "1.19.0",
-      "updatedAt": "2026-09-11T14:15:47Z",
+      "updatedAt": "2026-09-11T17:39:18Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Nauro-AI/nauro#readme",
@@ -22629,7 +22629,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.1",
-      "updatedAt": "2026-09-11T14:15:53Z",
+      "updatedAt": "2026-09-11T17:39:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/plori-ai/plori#readme",
@@ -22657,7 +22657,7 @@
         "accounting"
       ],
       "version": "1.10.2",
-      "updatedAt": "2026-09-11T14:15:55Z",
+      "updatedAt": "2026-09-11T17:39:21Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/RoboFinSystems/robosystems#readme",
@@ -22686,7 +22686,7 @@
         "x402"
       ],
       "version": "0.3.3",
-      "updatedAt": "2026-09-11T14:15:56Z",
+      "updatedAt": "2026-09-11T17:39:22Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/vaaya-ai/vaaya-mcp#readme",
@@ -22739,7 +22739,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.clicon%2Flotus/versions/1.27.0",
       "description": "Measure how AI assistants cite your brand. Returns measured data and ready-to-apply fixes.",
       "version": "1.27.0",
-      "updatedAt": "2026-09-11T14:16:07Z",
+      "updatedAt": "2026-09-11T17:39:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/martinendara/lotus-mcp#readme",
         "repository": "https://github.com/martinendara/lotus-mcp",
@@ -22765,12 +22765,12 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T14:16:08Z",
+      "updatedAt": "2026-09-11T17:39:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/desktop-commander/remote-desktop-commander#readme",
         "repository": "https://github.com/desktop-commander/remote-desktop-commander",
         "repositorySource": "github",
-        "stargazerCount": 25,
+        "stargazerCount": 26,
         "websiteUrl": "https://mcp.desktopcommander.app"
       }
     },
@@ -22789,7 +22789,7 @@
         "workflows"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:09Z",
+      "updatedAt": "2026-09-11T17:39:25Z",
       "metadata": {
         "readmeUrl": "https://github.com/glifxyz/glif-mcp-server#readme",
         "repository": "https://github.com/glifxyz/glif-mcp-server",
@@ -22805,7 +22805,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/app.lucid.mcp%2Flucid/versions/1.0.0",
       "description": "Lucid’s connector creates diagrams, searches, edits, shares, and retrieves docs to summarize.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:10Z",
+      "updatedAt": "2026-09-11T17:39:26Z",
       "metadata": {
         "readmeUrl": "https://github.com/lucidsoftware/lucid-mcp-server#readme",
         "repository": "https://github.com/lucidsoftware/lucid-mcp-server",
@@ -22832,7 +22832,7 @@
         "websocket"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T14:16:12Z",
+      "updatedAt": "2026-09-11T17:39:28Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pensados/sentinelx-cloud-core#readme",
@@ -22906,7 +22906,7 @@
         "readmeUrl": "https://github.com/chroma-core/chroma-mcp#readme",
         "repository": "https://github.com/chroma-core/chroma-mcp",
         "repositorySource": "github",
-        "stargazerCount": 592
+        "stargazerCount": 593
       }
     },
     {
@@ -22928,7 +22928,7 @@
         "mcp"
       ],
       "version": "2.12.11",
-      "updatedAt": "2026-09-11T14:16:20Z",
+      "updatedAt": "2026-09-11T17:39:29Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/azmartone67/dchub-mcp-server#readme",
@@ -22945,7 +22945,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/co.axiom%2Fmcp/versions/1.0.0",
       "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:22Z",
+      "updatedAt": "2026-09-11T17:39:30Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/axiomhq/mcp/tree/HEAD/apps/mcp",
@@ -22973,7 +22973,7 @@
         "w2-staffing"
       ],
       "version": "1.7.2",
-      "updatedAt": "2026-09-11T14:16:24Z",
+      "updatedAt": "2026-09-11T17:39:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tempguru-co/tempguru-mcp#readme",
@@ -23036,13 +23036,13 @@
         "mcp-server"
       ],
       "version": "0.15.7",
-      "updatedAt": "2026-09-11T14:16:28Z",
+      "updatedAt": "2026-09-11T17:39:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/apify/apify-mcp-server#readme",
         "repository": "https://github.com/apify/apify-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 6756
+        "stargazerCount": 6773
       }
     },
     {
@@ -23064,7 +23064,7 @@
         "cursor"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-09-11T14:16:30Z",
+      "updatedAt": "2026-09-11T17:39:35Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/atlassian/atlassian-mcp-server#readme",
@@ -23081,7 +23081,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.atom%2Fpremium-domains/versions/2.0.7",
       "description": "Search, appraise, trademark-check, and buy premium brandable domain names from Atom.com.",
       "version": "2.0.7",
-      "updatedAt": "2026-09-11T14:16:32Z",
+      "updatedAt": "2026-09-11T17:39:36Z",
       "metadata": {
         "readmeUrl": "https://github.com/atomdomains/atom-mcp-server#readme",
         "repository": "https://github.com/atomdomains/atom-mcp-server",
@@ -23096,7 +23096,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fatc/versions/1.0.1",
       "description": "Provides access to Avalara Tax Content: TTE configs, jobs, communications, lodging, autorental",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:33Z",
+      "updatedAt": "2026-09-11T17:39:38Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23112,7 +23112,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Favatax/versions/1.0.1",
       "description": "Access Avalara AvaTax API for tax calculation, transactions, nexus management, and compliance",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:34Z",
+      "updatedAt": "2026-09-11T17:39:39Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23128,7 +23128,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fbl/versions/1.0.0",
       "description": "Provides access to Avalara Tax Registration and Business Licenses APIs for filings and registrations",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:35Z",
+      "updatedAt": "2026-09-11T17:39:40Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23144,7 +23144,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fclassification/versions/1.0.0",
       "description": "Classify, validate & verify HS codes and access tariff compliance data for cross-border trade",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:37Z",
+      "updatedAt": "2026-09-11T17:39:41Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23160,7 +23160,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fcross-border/versions/1.0.0",
       "description": "Cross-border duty-rate and Trade & Tariff content lookups with product compliance and restrictions",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:38Z",
+      "updatedAt": "2026-09-11T17:39:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23176,7 +23176,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Fdocs/versions/1.0.1",
       "description": "Provides access to Avalara developer documentation, integration guides, and code examples",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:39Z",
+      "updatedAt": "2026-09-11T17:39:43Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23192,7 +23192,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Felr/versions/1.0.0",
       "description": "Provides access to Avalara E-Invoicing and Live Reporting APIs for document statuses and compliance",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:16:40Z",
+      "updatedAt": "2026-09-11T17:39:44Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23208,7 +23208,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.avalara%2Freturns/versions/1.0.1",
       "description": "Provides access to Avalara Global Returns API for tax returns, filing calendars, and compliance data",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:41Z",
+      "updatedAt": "2026-09-11T17:39:45Z",
       "metadata": {
         "readmeUrl": "https://github.com/avadev/mcp#readme",
         "repository": "https://github.com/avadev/mcp",
@@ -23224,7 +23224,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.blackduck%2Fmcp-server/versions/1.1.8",
       "description": "AI-powered security scanning using Black Duck Signal for vulnerability detection.",
       "version": "1.1.8",
-      "updatedAt": "2026-09-11T14:16:43Z",
+      "updatedAt": "2026-09-11T17:39:46Z",
       "metadata": {
         "readmeUrl": "https://github.com/blackducksoftware/mcp-server#readme",
         "repository": "https://github.com/blackducksoftware/mcp-server",
@@ -23238,7 +23238,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.breckenwander%2Ftravel-connector/versions/0.2.1",
       "description": "Search flights, hotels & experiences at all-in prices, then build a trip on breckenwander.com.",
       "version": "0.2.1",
-      "updatedAt": "2026-09-11T14:16:44Z",
+      "updatedAt": "2026-09-11T17:39:47Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/durwardjohnson/breckenwander-travel-connector#readme",
@@ -23262,7 +23262,7 @@
         "mcp"
       ],
       "version": "0.6.1",
-      "updatedAt": "2026-09-11T14:16:45Z",
+      "updatedAt": "2026-09-11T17:39:48Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/celigo/ai#readme",
@@ -23289,7 +23289,7 @@
         "web3"
       ],
       "version": "1.10.10",
-      "updatedAt": "2026-09-11T14:16:46Z",
+      "updatedAt": "2026-09-11T17:39:49Z",
       "metadata": {
         "readmeUrl": "https://github.com/chainstacklabs/mcp-server#readme",
         "repository": "https://github.com/chainstacklabs/mcp-server",
@@ -23317,7 +23317,7 @@
         "voice-ai"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T14:16:48Z",
+      "updatedAt": "2026-09-11T17:39:51Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
@@ -23334,7 +23334,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.easyship%2Fmcp/versions/0.6.5",
       "description": "Connect Easyship to compare rates, create shipments, buy labels, and track packages globally.",
       "version": "0.6.5",
-      "updatedAt": "2026-09-11T14:16:49Z",
+      "updatedAt": "2026-09-11T17:39:52Z",
       "metadata": {
         "readmeUrl": "https://github.com/easyship/easyship-mcp-plugin#readme",
         "repository": "https://github.com/easyship/easyship-mcp-plugin",
@@ -23348,7 +23348,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.figma.mcp%2Fmcp/versions/1.0.3",
       "description": "The Figma MCP server brings Figma design context directly into your AI workflow.",
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T14:16:50Z",
+      "updatedAt": "2026-09-11T17:39:53Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/figma/mcp-server-guide#readme",
@@ -23375,7 +23375,7 @@
         "model-context-protocol"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-09-11T14:16:52Z",
+      "updatedAt": "2026-09-11T17:39:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/getappniche/mcp#readme",
@@ -23391,7 +23391,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getfirmament%2Ffirmament/versions/0.1.1",
       "description": "Your team's shared, verified knowledge for AI agents: ask what's true, record what you learn.",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:16:54Z",
+      "updatedAt": "2026-09-11T17:39:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/spkenny455/firmament-mcp#readme",
         "repository": "https://github.com/spkenny455/firmament-mcp",
@@ -23406,7 +23406,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.getguru%2Fmcp-server/versions/1.0.2",
       "description": "Guru MCP Server - Connect AI tools to your Guru knowledge base",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:16:55Z",
+      "updatedAt": "2026-09-11T17:39:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/guruhq/remote-mcp-server#readme",
         "repository": "https://github.com/guruhq/remote-mcp-server",
@@ -23431,7 +23431,7 @@
         "wp-agent"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:16:56Z",
+      "updatedAt": "2026-09-11T17:39:57Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wp-agent-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wp-agent-mcp",
@@ -23457,7 +23457,7 @@
         "modelcontextprotocol"
       ],
       "version": "1.2.1",
-      "updatedAt": "2026-09-11T14:16:58Z",
+      "updatedAt": "2026-09-11T17:39:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/gleanwork/remote-mcp-server#readme",
         "repository": "https://github.com/gleanwork/remote-mcp-server",
@@ -23473,7 +23473,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.hitsteps%2Fanalytics-operations/versions/1.1.4",
       "description": "AI access to Hitsteps analytics, live visitors, uptime, goals, alerts, and chats.",
       "version": "1.1.4",
-      "updatedAt": "2026-09-11T14:16:59Z",
+      "updatedAt": "2026-09-11T17:39:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/Hitsteps/MCP#readme",
         "repository": "https://github.com/Hitsteps/MCP",
@@ -23500,7 +23500,7 @@
         "technical-drawing"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:17:00Z",
+      "updatedAt": "2026-09-11T17:40:01Z",
       "metadata": {
         "primaryLanguage": "Dockerfile",
         "readmeUrl": "https://github.com/imnoo-team/drawing-converter-mcp#readme",
@@ -23516,7 +23516,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.industry-lens%2Fmcp-public/versions/0.2.0",
       "description": "B2B SaaS competitor pricing changes, strategic moves, market landscapes, reports and comparisons.",
       "version": "0.2.0",
-      "updatedAt": "2026-09-11T14:17:01Z",
+      "updatedAt": "2026-09-11T17:40:02Z",
       "metadata": {
         "readmeUrl": "https://github.com/IndustryLensOp/industrylens-mcp-docs#readme",
         "repository": "https://github.com/IndustryLensOp/industrylens-mcp-docs",
@@ -23539,7 +23539,7 @@
         "trading"
       ],
       "version": "0.9.0",
-      "updatedAt": "2026-09-11T14:17:04Z",
+      "updatedAt": "2026-09-11T17:40:04Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/longbridge/longbridge-mcp#readme",
@@ -23559,7 +23559,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T14:17:06Z",
+      "updatedAt": "2026-09-11T17:40:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/mablhq/mabl-mcp-server#readme",
         "repository": "https://github.com/mablhq/mabl-mcp-server",
@@ -23586,7 +23586,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:17:07Z",
+      "updatedAt": "2026-09-11T17:40:06Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/macfax/macfax-mcp#readme",
@@ -23612,7 +23612,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T14:17:08Z",
+      "updatedAt": "2026-09-11T17:40:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anrawool/mailrith-agent-platform/tree/HEAD/packages/mcp-server",
@@ -23637,7 +23637,7 @@
         "persistent-memory"
       ],
       "version": "1.3.2",
-      "updatedAt": "2026-09-11T14:17:10Z",
+      "updatedAt": "2026-09-11T17:40:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gpitrella/memxus-remote-mcp#readme",
@@ -23653,14 +23653,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fazure/versions/3.0.0-beta.42",
       "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services.",
       "version": "3.0.0-beta.42",
-      "updatedAt": "2026-09-11T14:17:11Z",
+      "updatedAt": "2026-09-11T17:40:10Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Azure.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Azure.Mcp.Server",
-        "stargazerCount": 3665,
+        "stargazerCount": 3666,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server"
       }
     },
@@ -23671,14 +23671,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fmicrosoft-fabric/versions/1.4.0",
       "description": "MCP tools for interacting with Microsoft Fabric",
       "version": "1.4.0",
-      "updatedAt": "2026-09-11T14:17:13Z",
+      "updatedAt": "2026-09-11T17:40:12Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp/tree/HEAD/servers/Fabric.Mcp.Server",
         "repository": "https://github.com/microsoft/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "servers/Fabric.Mcp.Server",
-        "stargazerCount": 3665,
+        "stargazerCount": 3666,
         "websiteUrl": "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
       }
     },
@@ -23689,7 +23689,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fnuget/versions/1.4.16",
       "description": "A Model Context Protocol (MCP) server for NuGet.",
       "version": "1.4.16",
-      "updatedAt": "2026-09-11T14:17:14Z",
+      "updatedAt": "2026-09-11T17:40:13Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/NuGet/Home/tree/HEAD/mcp",
@@ -23706,7 +23706,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.microsoft%2Fsentinel-data-exploration/versions/1.0.1",
       "description": "Find relevant security data from Sentinel data lake for building effective agents. More:aka.ms/s/de",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:17:16Z",
+      "updatedAt": "2026-09-11T17:40:14Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/sentinel-data-exploration-mcp#readme",
         "repository": "https://github.com/microsoft/sentinel-data-exploration-mcp",
@@ -23725,7 +23725,7 @@
         "mcp-server"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:17:17Z",
+      "updatedAt": "2026-09-11T17:40:16Z",
       "metadata": {
         "readmeUrl": "https://github.com/mobbin/mobbin-mcp-server#readme",
         "repository": "https://github.com/mobbin/mobbin-mcp-server",
@@ -23747,7 +23747,7 @@
         "monday"
       ],
       "version": "0.0.1",
-      "updatedAt": "2026-09-11T14:17:18Z",
+      "updatedAt": "2026-09-11T17:40:17Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mondaycom/mcp#readme",
@@ -23770,7 +23770,7 @@
         "sports-betting"
       ],
       "version": "1.4.5",
-      "updatedAt": "2026-09-11T14:17:19Z",
+      "updatedAt": "2026-09-11T17:40:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/jessejohnsohn/negativeev-mcp#readme",
         "repository": "https://github.com/jessejohnsohn/negativeev-mcp",
@@ -23785,7 +23785,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.nitrosend%2Fnitrosend/versions/0.8.2",
       "description": "AI-native email marketing. Campaigns, automations, transactional, contacts, and analytics.",
       "version": "0.8.2",
-      "updatedAt": "2026-09-11T14:17:21Z",
+      "updatedAt": "2026-09-11T17:40:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/nitrosend/mcp#readme",
@@ -23802,7 +23802,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.opslevel%2Fmcp/versions/0.1.1",
       "description": "Query your OpsLevel internal developer portal: catalog, maturity data, and tech docs.",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:17:22Z",
+      "updatedAt": "2026-09-11T17:40:20Z",
       "metadata": {
         "readmeUrl": "https://github.com/OpsLevel/opslevel-mcp-remote#readme",
         "repository": "https://github.com/OpsLevel/opslevel-mcp-remote",
@@ -23829,7 +23829,7 @@
         "copilot"
       ],
       "version": "2.12.3",
-      "updatedAt": "2026-09-11T14:17:24Z",
+      "updatedAt": "2026-09-11T17:40:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/postmanlabs/postman-mcp-server#readme",
@@ -23846,7 +23846,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.publora%2Fmcp-server/versions/1.1.1",
       "description": "Schedule and publish to 10 social platforms: LinkedIn, X, Instagram, TikTok, YouTube, and more.",
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T14:17:25Z",
+      "updatedAt": "2026-09-11T17:40:23Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/publora/mcp-server#readme",
@@ -23875,7 +23875,7 @@
         "mcp"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:17:27Z",
+      "updatedAt": "2026-09-11T17:40:24Z",
       "metadata": {
         "readmeUrl": "https://github.com/qualityclouds/qualityclouds#readme",
         "repository": "https://github.com/qualityclouds/qualityclouds",
@@ -23900,7 +23900,7 @@
         "review-management"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:17:29Z",
+      "updatedAt": "2026-09-11T17:40:25Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/reputemap/mcp#readme",
@@ -23926,7 +23926,7 @@
         "website-screenshot"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:17:30Z",
+      "updatedAt": "2026-09-11T17:40:27Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screenshotscout/screenshotscout-mcp#readme",
@@ -23942,7 +23942,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sherweb%2Fplatform/versions/1.52.10",
       "description": "Sherweb Platform MCP server to manage subscriptions and orders. Use OpenID Connect to authenticate.",
       "version": "1.52.10",
-      "updatedAt": "2026-09-11T14:17:31Z",
+      "updatedAt": "2026-09-11T17:40:28Z",
       "metadata": {
         "readmeUrl": "https://github.com/sherweb/platform-mcp#readme",
         "repository": "https://github.com/sherweb/platform-mcp",
@@ -23969,7 +23969,7 @@
         "static-site"
       ],
       "version": "1.10.2",
-      "updatedAt": "2026-09-11T14:17:33Z",
+      "updatedAt": "2026-09-11T17:40:29Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shipstatic/mcp#readme",
@@ -23998,7 +23998,7 @@
         "swagger"
       ],
       "version": "0.40.0",
-      "updatedAt": "2026-09-11T14:17:35Z",
+      "updatedAt": "2026-09-11T17:40:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -24026,7 +24026,7 @@
         "swagger"
       ],
       "version": "0.33.0",
-      "updatedAt": "2026-09-11T14:17:37Z",
+      "updatedAt": "2026-09-11T17:40:33Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SmartBear/smartbear-mcp#readme",
@@ -24042,7 +24042,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.sonatype%2Fdependency-management-mcp-server/versions/1.0.2",
       "description": "Sonatype component intelligence: versions, security analysis, and Trust Score recommendations",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:17:38Z",
+      "updatedAt": "2026-09-11T17:40:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/sonatype/dependency-management-mcp-server#readme",
         "repository": "https://github.com/sonatype/dependency-management-mcp-server",
@@ -24060,7 +24060,7 @@
         "soracom"
       ],
       "version": "1.1.4",
-      "updatedAt": "2026-09-11T14:17:39Z",
+      "updatedAt": "2026-09-11T17:40:35Z",
       "metadata": {
         "readmeUrl": "https://github.com/soracom/mcp/tree/HEAD/servers/knowledge",
         "repository": "https://github.com/soracom/mcp",
@@ -24077,7 +24077,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackhawk%2Fstackhawk/versions/1.1.1",
       "description": "An MCP server that provides interaction with StackHawk's security scanning platform.",
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T14:17:40Z",
+      "updatedAt": "2026-09-11T17:40:36Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/stackhawk/stackhawk-mcp#readme",
@@ -24093,7 +24093,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.stackoverflow.mcp%2Fmcp/versions/1.1.3",
       "description": "Access Stack Overflow's trusted and verified technical questions and answers.",
       "version": "1.1.3",
-      "updatedAt": "2026-09-11T14:17:41Z",
+      "updatedAt": "2026-09-11T17:40:37Z",
       "metadata": {
         "readmeUrl": "https://github.com/StackExchange/Stack-MCP#readme",
         "repository": "https://github.com/StackExchange/Stack-MCP",
@@ -24118,13 +24118,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.4",
-      "updatedAt": "2026-09-11T14:17:43Z",
+      "updatedAt": "2026-09-11T17:40:39Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/stripe/agent-toolkit#readme",
         "repository": "https://github.com/stripe/agent-toolkit",
         "repositorySource": "github",
-        "stargazerCount": 1798
+        "stargazerCount": 1799
       }
     },
     {
@@ -24134,14 +24134,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.supabase%2Fmcp/versions/0.12.0",
       "description": "MCP server for interacting with the Supabase platform",
       "version": "0.12.0",
-      "updatedAt": "2026-09-11T14:17:45Z",
+      "updatedAt": "2026-09-11T17:40:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/supabase/mcp/tree/HEAD/packages/mcp-server-supabase",
         "repository": "https://github.com/supabase/mcp",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-server-supabase",
-        "stargazerCount": 2902,
+        "stargazerCount": 2903,
         "websiteUrl": "https://supabase.com/mcp"
       }
     },
@@ -24152,7 +24152,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.tallyfy%2Fmcp-server/versions/1.2.0",
       "description": "Automate tasks, processes, and approvals with AI.",
       "version": "1.2.0",
-      "updatedAt": "2026-09-11T14:17:46Z",
+      "updatedAt": "2026-09-11T17:40:41Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/tallyfy/mcp-public#readme",
@@ -24169,7 +24169,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.vercel%2Fvercel-mcp/versions/0.0.3",
       "description": "An MCP server for Vercel",
       "version": "0.0.3",
-      "updatedAt": "2026-09-11T14:17:47Z",
+      "updatedAt": "2026-09-11T17:40:42Z",
       "metadata": {
         "readmeUrl": "https://github.com/vercel/vercel-mcp-overview#readme",
         "repository": "https://github.com/vercel/vercel-mcp-overview",
@@ -24191,7 +24191,7 @@
         "business-critical-yes"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-09-11T14:17:49Z",
+      "updatedAt": "2026-09-11T17:40:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/webflow/mcp-server#readme",
@@ -24207,7 +24207,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/com.wix%2Fmcp/versions/1.0.2",
       "description": "A Model Context Protocol server for Wix AI tools",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:17:50Z",
+      "updatedAt": "2026-09-11T17:40:45Z",
       "metadata": {
         "readmeUrl": "https://github.com/wix/wix-mcp#readme",
         "repository": "https://github.com/wix/wix-mcp",
@@ -24226,7 +24226,7 @@
         "dax"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:17:51Z",
+      "updatedAt": "2026-09-11T17:40:46Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/workos/skills/tree/HEAD/mcp",
@@ -24256,7 +24256,7 @@
         "wordpress-mcp"
       ],
       "version": "2.0.0",
-      "updatedAt": "2026-09-11T14:17:52Z",
+      "updatedAt": "2026-09-11T17:40:47Z",
       "metadata": {
         "readmeUrl": "https://github.com/yaniv-fink/wpwriter-mcp#readme",
         "repository": "https://github.com/yaniv-fink/wpwriter-mcp",
@@ -24282,7 +24282,7 @@
         "privacy"
       ],
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T14:17:54Z",
+      "updatedAt": "2026-09-11T17:40:48Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Wuniq/wuniq-mcp#readme",
@@ -24310,7 +24310,7 @@
         "follower-export"
       ],
       "version": "2.6.0",
-      "updatedAt": "2026-09-11T14:17:56Z",
+      "updatedAt": "2026-09-11T17:40:50Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Xquik-dev/x-twitter-scraper#readme",
@@ -24345,7 +24345,7 @@
         "readmeUrl": "https://github.com/CoplayDev/unity-mcp#readme",
         "repository": "https://github.com/CoplayDev/unity-mcp",
         "repositorySource": "github",
-        "stargazerCount": 14133
+        "stargazerCount": 14136
       }
     },
     {
@@ -24365,7 +24365,7 @@
         "vibe-coding"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T14:17:58Z",
+      "updatedAt": "2026-09-11T17:40:51Z",
       "metadata": {
         "readmeUrl": "https://github.com/lovablelabs/mcp#readme",
         "repository": "https://github.com/lovablelabs/mcp",
@@ -24391,7 +24391,7 @@
         "model-context-protocol"
       ],
       "version": "0.13.0",
-      "updatedAt": "2026-09-11T14:18:00Z",
+      "updatedAt": "2026-09-11T17:40:52Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/mailkite/mailkite-mcp#readme",
@@ -24418,7 +24418,7 @@
         "presentations"
       ],
       "version": "5.9.0",
-      "updatedAt": "2026-09-11T14:18:01Z",
+      "updatedAt": "2026-09-11T17:40:54Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smartdatabrokers/slideforge-mcp#readme",
@@ -24434,14 +24434,14 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.svelte%2Fmcp/versions/0.1.26",
       "description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
       "version": "0.1.26",
-      "updatedAt": "2026-09-11T14:18:03Z",
+      "updatedAt": "2026-09-11T17:40:55Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/sveltejs/ai-tools/tree/HEAD/packages/mcp-stdio",
         "repository": "https://github.com/sveltejs/ai-tools",
         "repositorySource": "github",
         "repositorySubfolder": "packages/mcp-stdio",
-        "stargazerCount": 322,
+        "stargazerCount": 323,
         "websiteUrl": "https://svelte.dev/docs/mcp/overview"
       }
     },
@@ -24452,7 +24452,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/dev.vibeseo%2Fvibeseo/versions/0.1.3",
       "description": "SEO research, audits, backlinks, GSC, and content workflow tools for AI agents.",
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T14:18:04Z",
+      "updatedAt": "2026-09-11T17:40:56Z",
       "metadata": {
         "readmeUrl": "https://github.com/sultanlive/vibeseo-mcp#readme",
         "repository": "https://github.com/sultanlive/vibeseo-mcp",
@@ -24517,7 +24517,7 @@
         "spf"
       ],
       "version": "1.0.6",
-      "updatedAt": "2026-09-11T14:18:07Z",
+      "updatedAt": "2026-09-11T17:40:57Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/palisadeemail/palisade-mcp#readme",
@@ -24533,7 +24533,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/eu.ansvar%2Fgateway/versions/1.0.b661c6dc",
       "description": "Cited EU & global law, regulations & security frameworks via Ansvar Gateway. OAuth, free + paid.",
       "version": "1.0.b661c6dc",
-      "updatedAt": "2026-09-11T14:18:09Z",
+      "updatedAt": "2026-09-11T17:40:58Z",
       "metadata": {
         "readmeUrl": "https://github.com/Ansvar-Systems/ansvar-gateway#readme",
         "repository": "https://github.com/Ansvar-Systems/ansvar-gateway",
@@ -24583,7 +24583,7 @@
         "voice-agents"
       ],
       "version": "1.2.0",
-      "updatedAt": "2026-09-11T14:18:13Z",
+      "updatedAt": "2026-09-11T17:41:00Z",
       "metadata": {
         "primaryLanguage": "HTML",
         "readmeUrl": "https://github.com/saaslabsco/justcall-mcp-server#readme",
@@ -24643,7 +24643,7 @@
         "structured-data-extraction"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:18:18Z",
+      "updatedAt": "2026-09-11T17:41:01Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/RapierCraft/alterlab-mcp-server#readme",
@@ -24671,7 +24671,7 @@
         "news-api"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:18:19Z",
+      "updatedAt": "2026-09-11T17:41:02Z",
       "metadata": {
         "readmeUrl": "https://github.com/apitube/news-api-mcp#readme",
         "repository": "https://github.com/apitube/news-api-mcp",
@@ -24698,12 +24698,12 @@
         "design-system"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:18:21Z",
+      "updatedAt": "2026-09-11T17:41:03Z",
       "metadata": {
         "readmeUrl": "https://github.com/Appllama/appllama-skills#readme",
         "repository": "https://github.com/Appllama/appllama-skills",
         "repositorySource": "github",
-        "stargazerCount": 1498,
+        "stargazerCount": 1550,
         "websiteUrl": "https://appllama.io/mcp"
       }
     },
@@ -24726,7 +24726,7 @@
         "context"
       ],
       "version": "0.5.35",
-      "updatedAt": "2026-09-11T14:18:22Z",
+      "updatedAt": "2026-09-11T17:41:04Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
@@ -24755,7 +24755,7 @@
         "kubernetes"
       ],
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:18:23Z",
+      "updatedAt": "2026-09-11T17:41:06Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/controlplane-com/ai-plugin#readme",
@@ -24784,7 +24784,7 @@
         "x402"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:18:25Z",
+      "updatedAt": "2026-09-11T17:41:07Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/webmilmind1/deskcrew-mcp#readme",
@@ -24813,7 +24813,7 @@
         "ai-native"
       ],
       "version": "1.17.0",
-      "updatedAt": "2026-09-11T14:18:26Z",
+      "updatedAt": "2026-09-11T17:41:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Frihet-io/frihet-mcp#readme",
@@ -24841,7 +24841,7 @@
         "model-context-protocol"
       ],
       "version": "1.10.2",
-      "updatedAt": "2026-09-11T14:18:27Z",
+      "updatedAt": "2026-09-11T17:41:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
@@ -24858,7 +24858,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.AnimaApp%2Fanima/versions/1.0.0",
       "description": "Connect AI coding agents to Anima Playground, Figma, and your design system.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:18:29Z",
+      "updatedAt": "2026-09-11T17:41:11Z",
       "metadata": {
         "primaryLanguage": "Shell",
         "readmeUrl": "https://github.com/AnimaApp/mcp-server-guide#readme",
@@ -24886,7 +24886,7 @@
         "uta-v3"
       ],
       "version": "3.0.2",
-      "updatedAt": "2026-09-11T14:18:30Z",
+      "updatedAt": "2026-09-11T17:41:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Bitget-AI/agent-mcp#readme",
@@ -24902,7 +24902,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.CAST-Extend%2Fimaging-mcp-server/versions/3.0.4",
       "description": "MCP server exposing CAST Imaging software architecture insights to AI agents",
       "version": "3.0.4",
-      "updatedAt": "2026-09-11T14:18:31Z",
+      "updatedAt": "2026-09-11T17:41:13Z",
       "metadata": {
         "readmeUrl": "https://github.com/CAST-Extend/CAST-Imaging-Mcp#readme",
         "repository": "https://github.com/CAST-Extend/CAST-Imaging-Mcp",
@@ -24927,13 +24927,13 @@
         "mcp"
       ],
       "version": "1.9.0",
-      "updatedAt": "2026-09-11T14:18:33Z",
+      "updatedAt": "2026-09-11T17:41:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ChromeDevTools/chrome-devtools-mcp#readme",
         "repository": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
         "repositorySource": "github",
-        "stargazerCount": 51641
+        "stargazerCount": 51661
       }
     },
     {
@@ -24943,7 +24943,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ClickHouse%2Fmcp-clickhouse/versions/0.6.0",
       "description": "Official ClickHouse MCP server for querying and exploring ClickHouse clusters and chDB.",
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T14:18:35Z",
+      "updatedAt": "2026-09-11T17:41:16Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ClickHouse/mcp-clickhouse#readme",
@@ -24960,7 +24960,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.ComposioHQ%2Fcomposio/versions/1.0.5",
       "description": "Connect AI agents to 1000+ apps with managed authentication and tool-calling.",
       "version": "1.0.5",
-      "updatedAt": "2026-09-11T14:18:37Z",
+      "updatedAt": "2026-09-11T17:41:18Z",
       "metadata": {
         "readmeUrl": "https://github.com/ComposioHQ/GHMCP#readme",
         "repository": "https://github.com/ComposioHQ/GHMCP",
@@ -24983,7 +24983,7 @@
         "mcp-server"
       ],
       "version": "0.19.0",
-      "updatedAt": "2026-09-11T14:18:38Z",
+      "updatedAt": "2026-09-11T17:41:19Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/CrowdStrike/falcon-mcp#readme",
@@ -25011,7 +25011,7 @@
         "smithery"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-09-11T14:18:39Z",
+      "updatedAt": "2026-09-11T17:41:20Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Decodo/mcp-server#readme",
@@ -25037,7 +25037,7 @@
         "observability"
       ],
       "version": "7.0.0",
-      "updatedAt": "2026-09-11T14:18:41Z",
+      "updatedAt": "2026-09-11T17:41:21Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Dynatrace/dynatrace-for-ai#readme",
@@ -25066,7 +25066,7 @@
         "openssf"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-09-11T14:18:44Z",
+      "updatedAt": "2026-09-11T17:41:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/Guruprasath-Annadurai/Whitepact#readme",
@@ -25095,7 +25095,7 @@
         "ga4"
       ],
       "version": "1.2.5",
-      "updatedAt": "2026-09-11T14:18:45Z",
+      "updatedAt": "2026-09-11T17:41:25Z",
       "metadata": {
         "readmeUrl": "https://github.com/HYPD-AI/ads-mcp-plugin#readme",
         "repository": "https://github.com/HYPD-AI/ads-mcp-plugin",
@@ -25111,7 +25111,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.IgniteUI%2Figniteui-theming/versions/29.0.0",
       "description": "Generate Sass palettes, typography, elevations, and themes for Ignite UI components.",
       "version": "29.0.0",
-      "updatedAt": "2026-09-11T14:18:46Z",
+      "updatedAt": "2026-09-11T17:41:26Z",
       "metadata": {
         "primaryLanguage": "SCSS",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-theming#readme",
@@ -25138,7 +25138,7 @@
         "scaffolding"
       ],
       "version": "15.6.1",
-      "updatedAt": "2026-09-11T14:18:47Z",
+      "updatedAt": "2026-09-11T17:41:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/IgniteUI/igniteui-cli#readme",
@@ -25166,7 +25166,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.10",
-      "updatedAt": "2026-09-11T14:18:49Z",
+      "updatedAt": "2026-09-11T17:41:29Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/Karzone/TestAtlas#readme",
@@ -25182,7 +25182,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Krv-Labs%2Ftopos/versions/0.5.1",
       "description": "Structural code-quality tools for AI coding agents.",
       "version": "0.5.1",
-      "updatedAt": "2026-09-11T14:18:50Z",
+      "updatedAt": "2026-09-11T17:41:30Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Krv-Labs/topos#readme",
@@ -25211,7 +25211,7 @@
         "model-context-protocol"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:18:52Z",
+      "updatedAt": "2026-09-11T17:41:32Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/MachuraHarry/pipe#readme",
@@ -25239,7 +25239,7 @@
         "accessibility-testing"
       ],
       "version": "1.2.7",
-      "updatedAt": "2026-09-11T14:18:54Z",
+      "updatedAt": "2026-09-11T17:41:33Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/MasterPlayspots/motionspec#readme",
@@ -25258,7 +25258,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:18:56Z",
+      "updatedAt": "2026-09-11T17:41:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/OctoPerf/octoperf-claude-plugins#readme",
         "repository": "https://github.com/OctoPerf/octoperf-claude-plugins",
@@ -25277,7 +25277,7 @@
         "voice-assistant"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-09-11T14:18:57Z",
+      "updatedAt": "2026-09-11T17:41:35Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Omnidim/omnidim-mcp-server#readme",
@@ -25294,7 +25294,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Openly-Useful%2Fcitewire/versions/0.2.0",
       "description": "Attribution-first MCP server for free news sources and free article APIs.",
       "version": "0.2.0",
-      "updatedAt": "2026-09-11T14:18:59Z",
+      "updatedAt": "2026-09-11T17:41:36Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/Openly-Useful/citewire#readme",
@@ -25311,7 +25311,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.PagerDuty%2Fpagerduty-mcp/versions/0.2.1",
       "description": "PagerDuty's official MCP server which provides tools to interact with your PagerDuty account.",
       "version": "0.2.1",
-      "updatedAt": "2026-09-11T14:19:01Z",
+      "updatedAt": "2026-09-11T17:41:37Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/PagerDuty/pagerduty-mcp-server#readme",
@@ -25339,7 +25339,7 @@
         "google-analytics-alternative"
       ],
       "version": "2.13.11",
-      "updatedAt": "2026-09-11T14:19:02Z",
+      "updatedAt": "2026-09-11T17:41:39Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pascalebeier/hitkeep#readme",
@@ -25356,7 +25356,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.QWarranto%2Fleafengines/versions/2.0.8",
       "description": "🌱 Agricultural AI: Soil analysis, crop recommendations, weather forecasts. FREE TurboQuant.",
       "version": "2.0.8",
-      "updatedAt": "2026-09-11T14:19:04Z",
+      "updatedAt": "2026-09-11T17:41:40Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/QWarranto/leafengines-claude-mcp#readme",
@@ -25378,7 +25378,7 @@
         "ui5"
       ],
       "version": "1.12.4",
-      "updatedAt": "2026-09-11T14:19:06Z",
+      "updatedAt": "2026-09-11T17:41:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/SAP/open-ux-tools/tree/HEAD/packages/fiori-mcp-server",
@@ -25400,7 +25400,7 @@
         "webcrawler"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:19:08Z",
+      "updatedAt": "2026-09-11T17:41:43Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/ScrapeGraphAI/scrapegraph-mcp#readme",
@@ -25428,7 +25428,7 @@
         "mcp-tools"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:09Z",
+      "updatedAt": "2026-09-11T17:41:44Z",
       "metadata": {
         "primaryLanguage": "PHP",
         "readmeUrl": "https://github.com/Sendmux/sendmux-sdk/tree/HEAD/packages/python/mcp",
@@ -25456,7 +25456,7 @@
         "static-analysis"
       ],
       "version": "1.21.0",
-      "updatedAt": "2026-09-11T14:19:11Z",
+      "updatedAt": "2026-09-11T17:41:46Z",
       "metadata": {
         "primaryLanguage": "Java",
         "readmeUrl": "https://github.com/SonarSource/sonarqube-mcp-server#readme",
@@ -25479,7 +25479,7 @@
         "mcp-server"
       ],
       "version": "0.2.20",
-      "updatedAt": "2026-09-11T14:19:12Z",
+      "updatedAt": "2026-09-11T17:41:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/mcp-server#readme",
@@ -25503,7 +25503,7 @@
         "webcomponent"
       ],
       "version": "0.1.2",
-      "updatedAt": "2026-09-11T14:19:14Z",
+      "updatedAt": "2026-09-11T17:41:49Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/UI5/webcomponents-mcp-server#readme",
@@ -25531,7 +25531,7 @@
         "ed25519"
       ],
       "version": "2.4.0",
-      "updatedAt": "2026-09-11T14:19:15Z",
+      "updatedAt": "2026-09-11T16:35:57Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/Vortx-AI/emem#readme",
@@ -25548,7 +25548,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.Wopee-io%2Fwopee-mcp/versions/1.30.1",
       "description": "AI testing agents for web apps — dispatch test runs, crawls, fetch artifacts and status.",
       "version": "1.30.1",
-      "updatedAt": "2026-09-11T14:19:16Z",
+      "updatedAt": "2026-09-11T16:35:58Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wopee-io/wopee-mcp#readme",
@@ -25571,7 +25571,7 @@
         "trust"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-09-11T14:19:19Z",
+      "updatedAt": "2026-09-11T16:35:59Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/YugantM/hvtracker-mcp#readme",
@@ -25599,7 +25599,7 @@
         "ai-agent"
       ],
       "version": "1.0.5",
-      "updatedAt": "2026-09-11T14:19:20Z",
+      "updatedAt": "2026-09-11T16:36:00Z",
       "metadata": {
         "readmeUrl": "https://github.com/adkit/ads-mcp#readme",
         "repository": "https://github.com/adkit/ads-mcp",
@@ -25627,7 +25627,7 @@
         "ai-agents"
       ],
       "version": "0.21.5",
-      "updatedAt": "2026-09-11T14:19:21Z",
+      "updatedAt": "2026-09-11T16:36:02Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/agentic-hil/agentic-hil#readme",
@@ -25656,7 +25656,7 @@
         "cursor"
       ],
       "version": "1.5.1",
-      "updatedAt": "2026-09-11T14:19:23Z",
+      "updatedAt": "2026-09-11T16:36:03Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/alimbenhelal-pro/ALM-XPP-MCP#readme",
@@ -25683,7 +25683,7 @@
         "mcp-server"
       ],
       "version": "0.8.0",
-      "updatedAt": "2026-09-11T14:19:24Z",
+      "updatedAt": "2026-09-11T16:36:05Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/anilloutombam/mcp-failure-lab#readme",
@@ -25706,7 +25706,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:26Z",
+      "updatedAt": "2026-09-11T16:36:06Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25731,7 +25731,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:27Z",
+      "updatedAt": "2026-09-11T16:36:07Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25756,7 +25756,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:28Z",
+      "updatedAt": "2026-09-11T16:36:08Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25781,7 +25781,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:29Z",
+      "updatedAt": "2026-09-11T16:36:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25806,7 +25806,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:31Z",
+      "updatedAt": "2026-09-11T16:36:10Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25831,7 +25831,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:33Z",
+      "updatedAt": "2026-09-11T16:36:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25856,7 +25856,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:34Z",
+      "updatedAt": "2026-09-11T16:36:13Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25881,7 +25881,7 @@
         "yandex"
       ],
       "version": "1.8.0",
-      "updatedAt": "2026-09-11T14:19:35Z",
+      "updatedAt": "2026-09-11T16:36:14Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/antohins/seo-tools-mcp#readme",
@@ -25910,7 +25910,7 @@
         "ai-tools"
       ],
       "version": "0.5.0",
-      "updatedAt": "2026-09-11T14:19:37Z",
+      "updatedAt": "2026-09-11T16:36:15Z",
       "metadata": {
         "primaryLanguage": "Kotlin",
         "readmeUrl": "https://github.com/aoreshkov/kotlin-lib-mcp#readme",
@@ -25927,7 +25927,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.arm%2Farm-mcp/versions/2.4.0",
       "description": "Official Arm MCP server for code migration, optimization, and Arm architecture guidance",
       "version": "2.4.0",
-      "updatedAt": "2026-09-11T14:19:38Z",
+      "updatedAt": "2026-09-11T16:36:17Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/arm/mcp#readme",
@@ -25956,13 +25956,13 @@
         "knowlege-graph"
       ],
       "version": "0.23.2",
-      "updatedAt": "2026-09-11T14:19:39Z",
+      "updatedAt": "2026-09-11T16:36:18Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/basicmachines-co/basic-memory.git#readme",
         "repository": "https://github.com/basicmachines-co/basic-memory.git",
         "repositorySource": "github",
-        "stargazerCount": 3930
+        "stargazerCount": 3931
       }
     },
     {
@@ -25984,7 +25984,7 @@
         "data-extraction"
       ],
       "version": "2.11.2",
-      "updatedAt": "2026-09-11T14:19:41Z",
+      "updatedAt": "2026-09-11T16:36:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/brightdata/brightdata-mcp#readme",
@@ -26012,13 +26012,13 @@
         "sqlserver"
       ],
       "version": "1.2.3",
-      "updatedAt": "2026-09-11T14:19:43Z",
+      "updatedAt": "2026-09-11T16:36:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/bytebase/dbhub#readme",
         "repository": "https://github.com/bytebase/dbhub",
         "repositorySource": "github",
-        "stargazerCount": 3497
+        "stargazerCount": 3498
       }
     },
     {
@@ -26040,7 +26040,7 @@
         "agentic-coding"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:19:44Z",
+      "updatedAt": "2026-09-11T16:36:22Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/cap-js/mcp-server#readme",
@@ -26056,7 +26056,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.carterchencc%2Fnomas/versions/1.3.2",
       "description": "Parsed SEC events by CIK/CUSIP: 8-K items, Form 144, Form D, FTD. Not EDGAR HTML.",
       "version": "1.3.2",
-      "updatedAt": "2026-09-11T14:19:45Z",
+      "updatedAt": "2026-09-11T16:36:23Z",
       "metadata": {
         "readmeUrl": "https://github.com/carterchencc/nomas_mcp#readme",
         "repository": "https://github.com/carterchencc/nomas_mcp",
@@ -26083,7 +26083,7 @@
         "bug-detection"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T14:19:46Z",
+      "updatedAt": "2026-09-11T16:36:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/chriswu727/argus#readme",
@@ -26112,7 +26112,7 @@
         "documentation"
       ],
       "version": "0.1.5",
-      "updatedAt": "2026-09-11T14:19:48Z",
+      "updatedAt": "2026-09-11T16:36:26Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/cometchat/docs-mcp#readme",
@@ -26141,7 +26141,7 @@
         "context"
       ],
       "version": "0.4.81",
-      "updatedAt": "2026-09-11T14:19:49Z",
+      "updatedAt": "2026-09-11T16:36:27Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/contextstream/mcp-server#readme",
@@ -26158,7 +26158,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.devchad-cmd%2Fskilldb/versions/0.8.3",
       "description": "A registry of 5,900+ peer-authored skills any MCP agent can search and load on demand.",
       "version": "0.8.3",
-      "updatedAt": "2026-09-11T14:19:52Z",
+      "updatedAt": "2026-09-11T16:36:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/devchad-cmd/skilldb-sdk#readme",
@@ -26186,7 +26186,7 @@
         "model-context-protocol"
       ],
       "version": "1.8.4",
-      "updatedAt": "2026-09-11T14:19:53Z",
+      "updatedAt": "2026-09-11T16:36:29Z",
       "metadata": {
         "readmeUrl": "https://github.com/dsers/dsers-mcp-server#readme",
         "repository": "https://github.com/dsers/dsers-mcp-server",
@@ -26210,7 +26210,7 @@
         "observability"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T14:19:55Z",
+      "updatedAt": "2026-09-11T16:36:31Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/dynatrace-oss/dynatrace-managed-mcp#readme",
@@ -26226,7 +26226,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.f%2Fprompts.chat-mcp/versions/1.0.9",
       "description": "Search and retrieve AI prompts from prompts.chat, the social platform for AI prompts.",
       "version": "1.0.9",
-      "updatedAt": "2026-09-11T14:19:56Z",
+      "updatedAt": "2026-09-11T16:36:32Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/f/prompts.chat-mcp#readme",
@@ -26242,7 +26242,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.flinker-app%2Fifc-mcp/versions/0.1.17",
       "description": "Local IFC/BIM MCP server with IfcOpenShell Python in Pyodide and an IFC viewer.",
       "version": "0.1.17",
-      "updatedAt": "2026-09-11T14:19:57Z",
+      "updatedAt": "2026-09-11T16:36:33Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/flinker-app/ifc-mcp#readme",
@@ -26262,7 +26262,7 @@
         "tag-production"
       ],
       "version": "0.25.0",
-      "updatedAt": "2026-09-11T14:19:59Z",
+      "updatedAt": "2026-09-11T16:36:34Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/getsentry/sentry-mcp/tree/HEAD/packages/mcp-server",
@@ -26284,13 +26284,13 @@
         "mcp-server"
       ],
       "version": "1.12.1",
-      "updatedAt": "2026-09-11T14:20:00Z",
+      "updatedAt": "2026-09-11T16:36:36Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/github/github-mcp-server#readme",
         "repository": "https://github.com/github/github-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 32869
+        "stargazerCount": 32874
       }
     },
     {
@@ -26305,7 +26305,7 @@
         "mcp-server"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-09-11T14:20:02Z",
+      "updatedAt": "2026-09-11T16:36:38Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/goreleaser/mcp#readme",
@@ -26321,7 +26321,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.hashicorp%2Fterraform-mcp-server/versions/1.0.0",
       "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:20:04Z",
+      "updatedAt": "2026-09-11T16:36:39Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/hashicorp/terraform-mcp-server#readme",
@@ -26349,7 +26349,7 @@
         "services"
       ],
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T14:20:05Z",
+      "updatedAt": "2026-09-11T16:36:40Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/holomodular/ServiceBricks#readme",
@@ -26374,7 +26374,7 @@
         "gemini-cli-extension"
       ],
       "version": "1.59.0",
-      "updatedAt": "2026-09-11T14:20:07Z",
+      "updatedAt": "2026-09-11T16:36:41Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/hostinger/api-mcp-server#readme",
@@ -26402,13 +26402,13 @@
         "privacy"
       ],
       "version": "2.2.0",
-      "updatedAt": "2026-09-11T14:20:10Z",
+      "updatedAt": "2026-09-11T16:36:44Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/ihor-sokoliuk/mcp-searxng#readme",
         "repository": "https://github.com/ihor-sokoliuk/mcp-searxng",
         "repositorySource": "github",
-        "stargazerCount": 1221
+        "stargazerCount": 1222
       }
     },
     {
@@ -26430,7 +26430,7 @@
         "rag"
       ],
       "version": "4.16.0",
-      "updatedAt": "2026-09-11T14:20:13Z",
+      "updatedAt": "2026-09-11T16:36:46Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/jagoff/memo#readme",
@@ -26457,7 +26457,7 @@
         "jfrog-mcp"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:20:15Z",
+      "updatedAt": "2026-09-11T16:36:49Z",
       "metadata": {
         "readmeUrl": "https://github.com/jfrog/jfrog-mcp-server#readme",
         "repository": "https://github.com/jfrog/jfrog-mcp-server",
@@ -26472,7 +26472,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.likhithreddy%2Ffittok/versions/0.11.1",
       "description": "Retrieve only the relevant code for a codebase question, within a token budget.",
       "version": "0.11.1",
-      "updatedAt": "2026-09-11T14:20:17Z",
+      "updatedAt": "2026-09-11T16:36:50Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/likhithreddy/fittok#readme",
@@ -26488,7 +26488,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-devkit-server/versions/0.8.2",
       "description": "Provides AI assistants with direct access to Mapbox developer APIs and documentation.",
       "version": "0.8.2",
-      "updatedAt": "2026-09-11T14:20:18Z",
+      "updatedAt": "2026-09-11T16:36:51Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-devkit-server#readme",
@@ -26504,7 +26504,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.mapbox%2Fmcp-server/versions/99.0.0-dev",
       "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
       "version": "99.0.0-dev",
-      "updatedAt": "2026-09-11T14:20:20Z",
+      "updatedAt": "2026-09-11T16:36:53Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mapbox/mcp-server#readme",
@@ -26520,7 +26520,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.microsoft%2FEnterpriseMCP/versions/1.0.0",
       "description": "Official Microsoft MCP Server to query Microsoft Entra data using natural language",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:20:21Z",
+      "updatedAt": "2026-09-11T16:36:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/microsoft/EnterpriseMCP#readme",
         "repository": "https://github.com/microsoft/EnterpriseMCP",
@@ -26541,7 +26541,7 @@
         "mcp-server"
       ],
       "version": "1.0.2026090704",
-      "updatedAt": "2026-09-11T14:20:24Z",
+      "updatedAt": "2026-09-11T16:36:55Z",
       "metadata": {
         "primaryLanguage": "C#",
         "readmeUrl": "https://github.com/microsoft/mcp-dotnet-samples#readme",
@@ -26558,7 +26558,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.miroapp%2Fmcp-server/versions/1.0.2",
       "description": "Official Miro MCP server - Supports context to code and creating diagrams, docs, and data tables.",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:20:28Z",
+      "updatedAt": "2026-09-11T16:36:59Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/miroapp/miro-ai#readme",
@@ -26586,7 +26586,7 @@
         "mcp-server-card"
       ],
       "version": "0.7.7",
-      "updatedAt": "2026-09-11T14:20:29Z",
+      "updatedAt": "2026-09-11T16:37:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/agent-ready-mcp#readme",
@@ -26615,7 +26615,7 @@
         "mcp"
       ],
       "version": "0.8.11",
-      "updatedAt": "2026-09-11T14:20:31Z",
+      "updatedAt": "2026-09-11T16:37:02Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mlava/scholar-sidekick-mcp#readme",
@@ -26639,7 +26639,7 @@
         "mongodb-database"
       ],
       "version": "2.1.0",
-      "updatedAt": "2026-09-11T14:20:34Z",
+      "updatedAt": "2026-09-11T16:37:03Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/mongodb-js/mongodb-mcp-server#readme",
@@ -26667,14 +26667,14 @@
         "influxdb"
       ],
       "version": "2.11.0",
-      "updatedAt": "2026-09-11T14:20:35Z",
+      "updatedAt": "2026-09-11T16:37:04Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/netdata/netdata/tree/HEAD/docs/netdata-ai/mcp",
         "repository": "https://github.com/netdata/netdata",
         "repositorySource": "github",
         "repositorySubfolder": "docs/netdata-ai/mcp",
-        "stargazerCount": 80484,
+        "stargazerCount": 80482,
         "websiteUrl": "https://www.netdata.cloud"
       }
     },
@@ -26685,7 +26685,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.oakallow%2Foakallow/versions/1.0.0",
       "description": "Runtime permission, approval, and audit layer for AI agent tool execution.",
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:20:37Z",
+      "updatedAt": "2026-09-11T16:37:06Z",
       "metadata": {
         "readmeUrl": "https://github.com/oakallow/oakallow-mcp#readme",
         "repository": "https://github.com/oakallow/oakallow-mcp",
@@ -26713,7 +26713,7 @@
         "local-first"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T14:20:38Z",
+      "updatedAt": "2026-09-11T16:37:07Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/oleksiijko/pmb#readme",
@@ -26741,7 +26741,7 @@
         "mcp"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:20:39Z",
+      "updatedAt": "2026-09-11T16:37:08Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/openaccountants/openaccountants#readme",
@@ -26769,7 +26769,7 @@
         "section-301"
       ],
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T14:20:41Z",
+      "updatedAt": "2026-09-11T16:37:09Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/opsloft/tariff-resolver#readme",
@@ -26798,7 +26798,7 @@
         "video-editing"
       ],
       "version": "0.3.0",
-      "updatedAt": "2026-09-11T14:20:42Z",
+      "updatedAt": "2026-09-11T16:37:11Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/opus-pro/opusclip-mcp#readme",
@@ -26815,7 +26815,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.parseablehq%2Fparseable-mcp-server/versions/0.2.16",
       "description": "Model Context Protocol server for Parseable. Lets LLMs discover and query Parseable.",
       "version": "0.2.16",
-      "updatedAt": "2026-09-11T14:20:44Z",
+      "updatedAt": "2026-09-11T16:37:12Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/parseablehq/parseable-mcp-server#readme",
@@ -26831,7 +26831,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.patrickchugh%2Fterravision/versions/0.47.0",
       "description": "Cloud architecture diagrams generated from terraform plan, with official AWS, Azure, GCP icons",
       "version": "0.47.0",
-      "updatedAt": "2026-09-11T14:20:45Z",
+      "updatedAt": "2026-09-11T16:37:13Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/patrickchugh/terravision#readme",
@@ -26860,7 +26860,7 @@
         "ucg-fiber"
       ],
       "version": "0.21.2",
-      "updatedAt": "2026-09-11T14:20:46Z",
+      "updatedAt": "2026-09-11T16:37:14Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/pete-builds/mcp-unifi#readme",
@@ -26885,7 +26885,7 @@
         "server"
       ],
       "version": "1.0.0",
-      "updatedAt": "2026-09-11T14:20:48Z",
+      "updatedAt": "2026-09-11T16:37:16Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/pgEdge/pgedge-postgres-mcp#readme",
@@ -26913,7 +26913,7 @@
         "model-context-protocol"
       ],
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T14:20:49Z",
+      "updatedAt": "2026-09-11T16:37:17Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/prest/prest-mcp-adapter#readme",
@@ -26937,7 +26937,7 @@
         "windsurf"
       ],
       "version": "2.3.2",
-      "updatedAt": "2026-09-11T14:20:50Z",
+      "updatedAt": "2026-09-11T16:37:18Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/pubnub/pubnub-mcp-server#readme",
@@ -26954,7 +26954,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.quicknode%2Fmcp/versions/1.0.1",
       "description": "Manage your blockchain infrastructure across 80+ chains with your agents.",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:20:52Z",
+      "updatedAt": "2026-09-11T16:37:19Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/quicknode/agent-plugins#readme",
@@ -26967,7 +26967,7 @@
       "identifier": "urn:air:registry.modelcontextprotocol.io:io.github.rigour-labs:rigour",
       "displayName": "Rigour",
       "type": "application/mcp-server+json",
-      "url": "https://api.mcp.github.com/v0.1/servers/io.github.rigour-labs%2Frigour/versions/6.0.0",
+      "url": "https://api.mcp.github.com/v0.1/servers/io.github.rigour-labs%2Frigour/versions/6.1.0",
       "description": "Quality gates for AI agents. Lint, test, build checks with memory persistence.",
       "tags": [
         "agentic-workflow",
@@ -26981,8 +26981,8 @@
         "llm",
         "mcp"
       ],
-      "version": "6.0.0",
-      "updatedAt": "2026-09-11T14:20:53Z",
+      "version": "6.1.0",
+      "updatedAt": "2026-09-11T16:37:21Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/rigour-labs/rigour#readme",
@@ -26998,7 +26998,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.salahawad%2Foutlook-personal-mcp/versions/0.1.1",
       "description": "Full-control MCP server for a personal Outlook.com mailbox and calendar (Microsoft Graph).",
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:20:56Z",
+      "updatedAt": "2026-09-11T16:37:23Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/salahawad/outlook-personal-mcp#readme",
@@ -27018,7 +27018,7 @@
         "sas-osp"
       ],
       "version": "1.14.2",
-      "updatedAt": "2026-09-11T14:20:57Z",
+      "updatedAt": "2026-09-11T16:37:24Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/sassoftware/sas-mcp-server#readme",
@@ -27046,7 +27046,7 @@
         "tiktok"
       ],
       "version": "0.14.1",
-      "updatedAt": "2026-09-11T14:20:59Z",
+      "updatedAt": "2026-09-11T16:37:25Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/scavio-ai/scavio-mcp#readme",
@@ -27062,7 +27062,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.serpapi%2Fserpapi-mcp/versions/1.0.3",
       "description": "Official SerpApi MCP server for Google, Bing, and other search engines.",
       "version": "1.0.3",
-      "updatedAt": "2026-09-11T14:21:01Z",
+      "updatedAt": "2026-09-11T16:37:27Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/serpapi/serpapi-mcp#readme",
@@ -27087,7 +27087,7 @@
         "typescript"
       ],
       "version": "1.1.1",
-      "updatedAt": "2026-09-11T14:21:02Z",
+      "updatedAt": "2026-09-11T16:37:28Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/shariqriazz/google-ai-search-mcp#readme",
@@ -27115,7 +27115,7 @@
         "semantic-scholar"
       ],
       "version": "1.7.4",
-      "updatedAt": "2026-09-11T14:21:06Z",
+      "updatedAt": "2026-09-11T16:37:29Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/semantic-scholar-mcp#readme",
@@ -27143,7 +27143,7 @@
         "drug-repurposing"
       ],
       "version": "1.3.6",
-      "updatedAt": "2026-09-11T14:21:07Z",
+      "updatedAt": "2026-09-11T16:37:31Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/smaniches/uniprot-mcp#readme",
@@ -27159,7 +27159,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.smythmyke%2Fgovtoolspro-mcp-server/versions/0.1.3",
       "description": "Workflow tools for federal contractors: go/no-go scoring, incumbent intel, recompete, NECO.",
       "version": "0.1.3",
-      "updatedAt": "2026-09-11T14:21:08Z",
+      "updatedAt": "2026-09-11T16:37:32Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/smythmyke/govtoolspro-mcp-server#readme",
@@ -27176,7 +27176,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.snyk%2Fsaw-mcp/versions/1.1.2",
       "description": "MCP server for Snyk API & Web — DAST scanning, findings management, and vulnerability triage",
       "version": "1.1.2",
-      "updatedAt": "2026-09-11T14:21:10Z",
+      "updatedAt": "2026-09-11T16:37:33Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/snyk/saw-mcp#readme",
@@ -27192,7 +27192,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.sourcegraph%2Fmcp/versions/0.1.0",
       "description": "Sourcegraph code search, semantic search, go-to-definition, find-references, and diff search.",
       "version": "0.1.0",
-      "updatedAt": "2026-09-11T14:21:11Z",
+      "updatedAt": "2026-09-11T16:37:34Z",
       "metadata": {
         "readmeUrl": "https://github.com/sourcegraph-community/mcpregistry#readme",
         "repository": "https://github.com/sourcegraph-community/mcpregistry",
@@ -27219,7 +27219,7 @@
         "stackql"
       ],
       "version": "0.11.669",
-      "updatedAt": "2026-09-11T14:21:12Z",
+      "updatedAt": "2026-09-11T16:37:36Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/stackql/stackql#readme",
@@ -27244,7 +27244,7 @@
         "skillsmp"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:21:13Z",
+      "updatedAt": "2026-09-11T16:37:37Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/tambo-labs/charming-mcp#readme",
@@ -27261,7 +27261,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.tavily-ai%2Ftavily-mcp/versions/0.2.15",
       "description": "MCP server for advanced web search using Tavily",
       "version": "0.2.15",
-      "updatedAt": "2026-09-11T14:21:14Z",
+      "updatedAt": "2026-09-11T16:37:38Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/tavily-ai/tavily-mcp#readme",
@@ -27289,7 +27289,7 @@
         "ai-agents"
       ],
       "version": "3.0.2",
-      "updatedAt": "2026-09-11T14:21:16Z",
+      "updatedAt": "2026-09-11T16:37:39Z",
       "metadata": {
         "primaryLanguage": "JavaScript",
         "readmeUrl": "https://github.com/uizze/uizze#readme",
@@ -27312,13 +27312,13 @@
         "vibe-coding"
       ],
       "version": "4.1.0",
-      "updatedAt": "2026-09-11T14:21:17Z",
+      "updatedAt": "2026-09-11T16:37:40Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/upstash/context7#readme",
         "repository": "https://github.com/upstash/context7",
         "repositorySource": "github",
-        "stargazerCount": 61882,
+        "stargazerCount": 61885,
         "websiteUrl": "https://context7.com"
       }
     },
@@ -27329,7 +27329,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.venomseven%2Fnslookup/versions/1.6.0",
       "description": "DNS lookups, health reports, SSL certs, security scans, GEO scoring, uptime checks",
       "version": "1.6.0",
-      "updatedAt": "2026-09-11T14:21:20Z",
+      "updatedAt": "2026-09-11T16:37:42Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/NsLookup-io/nslookup-mcp#readme",
@@ -27352,7 +27352,7 @@
         "mcp"
       ],
       "version": "0.3.6",
-      "updatedAt": "2026-09-11T14:21:27Z",
+      "updatedAt": "2026-09-11T16:37:43Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/vercel/next-devtools-mcp#readme",
@@ -27380,7 +27380,7 @@
         "spl-token"
       ],
       "version": "1.0.9",
-      "updatedAt": "2026-09-11T14:21:29Z",
+      "updatedAt": "2026-09-11T16:37:44Z",
       "metadata": {
         "readmeUrl": "https://github.com/vybenetwork/solana-mcp-vybe#readme",
         "repository": "https://github.com/vybenetwork/solana-mcp-vybe",
@@ -27407,13 +27407,13 @@
         "gemini-cli-extension"
       ],
       "version": "0.2.50",
-      "updatedAt": "2026-09-11T14:21:48Z",
+      "updatedAt": "2026-09-11T16:37:45Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/wonderwhy-er/DesktopCommanderMCP#readme",
         "repository": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
         "repositorySource": "github",
-        "stargazerCount": 9540
+        "stargazerCount": 9542
       }
     },
     {
@@ -27426,7 +27426,7 @@
         "ai-agents"
       ],
       "version": "0.9.2",
-      "updatedAt": "2026-09-11T14:21:50Z",
+      "updatedAt": "2026-09-11T16:37:47Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zation/agent-radar#readme",
@@ -27442,7 +27442,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.github.zereight%2Fgitlab-mcp/versions/2.1.61",
       "description": "GitLab MCP server for projects, merge requests, issues, pipelines, wiki, releases, and more.",
       "version": "2.1.61",
-      "updatedAt": "2026-09-11T14:22:03Z",
+      "updatedAt": "2026-09-11T16:37:48Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/zereight/gitlab-mcp#readme",
@@ -27470,7 +27470,7 @@
         "zpa"
       ],
       "version": "0.15.4",
-      "updatedAt": "2026-09-11T14:22:10Z",
+      "updatedAt": "2026-09-11T16:37:50Z",
       "metadata": {
         "primaryLanguage": "Python",
         "readmeUrl": "https://github.com/zscaler/zscaler-mcp-server#readme",
@@ -27497,7 +27497,7 @@
         "typescript"
       ],
       "version": "0.1.1",
-      "updatedAt": "2026-09-11T14:22:13Z",
+      "updatedAt": "2026-09-11T16:37:52Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/screen-arts/mediawork-mcp#readme",
@@ -27525,7 +27525,7 @@
         "url-shortener"
       ],
       "version": "3.1.0",
-      "updatedAt": "2026-09-11T14:22:14Z",
+      "updatedAt": "2026-09-11T16:37:53Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/PicSeeInc/picsee-mcp#readme",
@@ -27541,7 +27541,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.port%2FPort/versions/1.0.2",
       "description": "Port.io mcp server",
       "version": "1.0.2",
-      "updatedAt": "2026-09-11T14:22:15Z",
+      "updatedAt": "2026-09-11T16:37:54Z",
       "metadata": {
         "readmeUrl": "https://github.com/port-labs/remote-mcp-server#readme",
         "repository": "https://github.com/port-labs/remote-mcp-server",
@@ -27556,7 +27556,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.shipbook%2Fmcp/versions/1.1.0",
       "description": "Debug production issues using Shipbook logs and Loglytics error insights.",
       "version": "1.1.0",
-      "updatedAt": "2026-09-11T14:22:18Z",
+      "updatedAt": "2026-09-11T16:37:55Z",
       "metadata": {
         "readmeUrl": "https://github.com/ShipBook/shipbook-mcp#readme",
         "repository": "https://github.com/ShipBook/shipbook-mcp",
@@ -27577,7 +27577,7 @@
         "sast"
       ],
       "version": "1.1304.2",
-      "updatedAt": "2026-09-11T14:22:19Z",
+      "updatedAt": "2026-09-11T16:37:56Z",
       "metadata": {
         "primaryLanguage": "Go",
         "readmeUrl": "https://github.com/snyk/studio-mcp#readme",
@@ -27593,7 +27593,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/io.unstructured%2Ftransform/versions/0.7.2",
       "description": "Turn documents into structured, AI-ready data by parsing, enriching, chunking, and embedding.",
       "version": "0.7.2",
-      "updatedAt": "2026-09-11T14:22:20Z",
+      "updatedAt": "2026-09-11T16:37:57Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Unstructured-IO/unstructured-mcp-integrations#readme",
@@ -27638,7 +27638,7 @@
         "readmeUrl": "https://github.com/makenotion/notion-mcp-server#readme",
         "repository": "https://github.com/makenotion/notion-mcp-server",
         "repositorySource": "github",
-        "stargazerCount": 4625
+        "stargazerCount": 4626
       }
     },
     {
@@ -27656,7 +27656,7 @@
         "speedtest"
       ],
       "version": "1.1.3",
-      "updatedAt": "2026-09-11T14:22:25Z",
+      "updatedAt": "2026-09-11T16:37:59Z",
       "metadata": {
         "readmeUrl": "https://github.com/SpeedOfMe/speedofme-mcp#readme",
         "repository": "https://github.com/SpeedOfMe/speedofme-mcp",
@@ -27754,7 +27754,7 @@
         "readmeUrl": "https://github.com/microsoft/markitdown#readme",
         "repository": "https://github.com/microsoft/markitdown",
         "repositorySource": "github",
-        "stargazerCount": 182601
+        "stargazerCount": 182637
       }
     },
     {
@@ -27774,7 +27774,7 @@
         "readmeUrl": "https://github.com/microsoft/playwright-mcp#readme",
         "repository": "https://github.com/microsoft/playwright-mcp",
         "repositorySource": "github",
-        "stargazerCount": 37010
+        "stargazerCount": 37014
       }
     },
     {
@@ -27818,7 +27818,7 @@
         "readmeUrl": "https://github.com/neondatabase/mcp-server-neon#readme",
         "repository": "https://github.com/neondatabase/mcp-server-neon",
         "repositorySource": "github",
-        "stargazerCount": 637
+        "stargazerCount": 640
       }
     },
     {
@@ -27861,7 +27861,7 @@
         "model-context-protocol"
       ],
       "version": "5.22.1",
-      "updatedAt": "2026-09-11T14:22:39Z",
+      "updatedAt": "2026-09-11T16:38:00Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/claude-faf-mcp#readme",
@@ -27890,7 +27890,7 @@
         "typescript"
       ],
       "version": "3.0.2",
-      "updatedAt": "2026-09-11T14:22:40Z",
+      "updatedAt": "2026-09-11T16:38:01Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/Wolfe-Jam/faf-mcp#readme",
@@ -27925,7 +27925,7 @@
         "readmeUrl": "https://github.com/oraios/serena#readme",
         "repository": "https://github.com/oraios/serena",
         "repositorySource": "github",
-        "stargazerCount": 29180
+        "stargazerCount": 29187
       }
     },
     {
@@ -27947,7 +27947,7 @@
         "rust"
       ],
       "version": "1.3.5",
-      "updatedAt": "2026-09-11T14:22:43Z",
+      "updatedAt": "2026-09-11T16:38:03Z",
       "metadata": {
         "primaryLanguage": "Rust",
         "readmeUrl": "https://github.com/sylin-org/ghostlight#readme",
@@ -27976,7 +27976,7 @@
         "typescript"
       ],
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:22:45Z",
+      "updatedAt": "2026-09-11T16:38:04Z",
       "metadata": {
         "primaryLanguage": "TypeScript",
         "readmeUrl": "https://github.com/gamedevpl/www.gamedev.pl#readme",
@@ -28035,7 +28035,7 @@
       "url": "https://api.mcp.github.com/v0.1/servers/uk.sadiqoon%2Fsakh/versions/1.0.1",
       "description": "Ayatollah Khamenei corpus: fatwas, lectures, knowledge graph. Arabic/Persian. Research access.",
       "version": "1.0.1",
-      "updatedAt": "2026-09-11T14:22:49Z",
+      "updatedAt": "2026-09-11T16:38:05Z",
       "metadata": {
         "readmeUrl": "https://github.com/SADIQOON-LTD/sakh-mcp#readme",
         "repository": "https://github.com/SADIQOON-LTD/sakh-mcp",
@@ -28068,7 +28068,7 @@
         "readmeUrl": "https://github.com/zapier/zapier-mcp#readme",
         "repository": "https://github.com/zapier/zapier-mcp",
         "repositorySource": "github",
-        "stargazerCount": 405
+        "stargazerCount": 406
       }
     }
   ]

--- a/ai-catalog.json
+++ b/ai-catalog.json
@@ -20570,6 +20570,25 @@
       "type": "application/mcp-server+json"
     },
     {
+      "identifier": "urn:air:github.com:seancrecord:scvd-general-store-repo:scvd-general-store-plugin",
+      "displayName": "SCVD General Store (plugin)",
+      "mediaType": "application/vnd.github.copilot-plugin",
+      "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/.claude-plugin/plugin.json",
+      "description": "Evidence observatory for agentic commerce: x402 preflight, receipt checks, settlement attestations. The store's MCP door and its skill, as one installable plugin.",
+      "tags": [
+        "x402",
+        "agentic-commerce",
+        "verification",
+        "mcp-server",
+        "skill"
+      ],
+      "metadata": {
+        "sourceSet": "seancrecord/scvd-general-store-repo",
+        "repoPath": ".claude-plugin/plugin.json"
+      },
+      "type": "application/vnd.github.copilot-plugin"
+    },
+    {
       "identifier": "urn:air:github.com:seancrecord:scvd-general-store-repo:scvd-general-store",
       "displayName": "SCVD General Store",
       "mediaType": "application/ai-skill",

--- a/catalog/seancrecord/scvd-general-store-mcp.json
+++ b/catalog/seancrecord/scvd-general-store-mcp.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "urn:ai:registry.modelcontextprotocol.io:store.scvd:general-store",
+  "displayName": "SCVD General Store",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://registry.modelcontextprotocol.io/v0/servers/store.scvd%2Fgeneral-store/versions/0.2.3",
+  "description": "Evidence observatory for agentic commerce: x402 preflight, receipt checks, settlement attestations.",
+  "tags": [
+    "x402",
+    "agentic-commerce",
+    "conformance",
+    "verification",
+    "signed-artifacts",
+    "attestation",
+    "mcp",
+    "usdc",
+    "payments"
+  ],
+  "version": "0.2.3",
+  "metadata": {
+    "repository": "https://github.com/seancrecord/scvd-general-store-repo",
+    "repositorySource": "github",
+    "websiteUrl": "https://scvd.store",
+    "readmeUrl": "https://github.com/seancrecord/scvd-general-store-repo#readme"
+  }
+}

--- a/catalog/seancrecord/scvd-general-store-plugin.json
+++ b/catalog/seancrecord/scvd-general-store-plugin.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "urn:ai:github.com:seancrecord:scvd-general-store-repo:scvd-general-store-plugin",
+  "displayName": "SCVD General Store (plugin)",
+  "mediaType": "application/vnd.github.copilot-plugin",
+  "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/.claude-plugin/plugin.json",
+  "description": "Evidence observatory for agentic commerce: x402 preflight, receipt checks, settlement attestations. The store's MCP door and its skill, as one installable plugin.",
+  "tags": [
+    "x402",
+    "agentic-commerce",
+    "verification",
+    "mcp-server",
+    "skill"
+  ],
+  "metadata": {
+    "sourceSet": "seancrecord/scvd-general-store-repo",
+    "repoPath": ".claude-plugin/plugin.json"
+  }
+}

--- a/catalog/seancrecord/scvd-general-store.json
+++ b/catalog/seancrecord/scvd-general-store.json
@@ -3,15 +3,19 @@
   "displayName": "SCVD General Store",
   "mediaType": "application/ai-skill",
   "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/skills/scvd-general-store/SKILL.md",
-  "description": "A live x402 practice counter with real settlement from $0.004, free conformance checking for any issuer's signed x402 offers and receipts, and a signed evidence observatory for agentic commerce.",
+  "description": "Evidence observatory for agentic commerce: free x402 preflight of any endpoint, free conformance checks of any issuer's signed offers and receipts, and a live practice counter from $0.001. Every artifact is ed25519-signed and verifies free.",
   "tags": [
     "x402",
+    "agentic-commerce",
+    "conformance",
+    "verification",
+    "signed-artifacts",
+    "usdc",
     "payments",
-    "mcp-server",
-    "agent-commerce"
+    "skill"
   ],
   "metadata": {
-    "sourceSet": "scvd-general-store-repo",
+    "sourceSet": "seancrecord/scvd-general-store-repo",
     "repoPath": "skills/scvd-general-store/SKILL.md"
   }
 }

--- a/catalog/seancrecord/scvd-general-store.json
+++ b/catalog/seancrecord/scvd-general-store.json
@@ -1,0 +1,17 @@
+{
+  "identifier": "urn:ai:github.com:seancrecord:scvd-general-store-repo:scvd-general-store",
+  "displayName": "SCVD General Store",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/skills/scvd-general-store/SKILL.md",
+  "description": "A live x402 practice counter with real settlement from $0.004, free conformance checking for any issuer's signed x402 offers and receipts, and a signed evidence observatory for agentic commerce.",
+  "tags": [
+    "x402",
+    "payments",
+    "mcp-server",
+    "agent-commerce"
+  ],
+  "metadata": {
+    "sourceSet": "scvd-general-store-repo",
+    "repoPath": "skills/scvd-general-store/SKILL.md"
+  }
+}

--- a/catalog/seancrecord/x402-before-you-pay.json
+++ b/catalog/seancrecord/x402-before-you-pay.json
@@ -1,0 +1,19 @@
+{
+  "identifier": "urn:ai:github.com:seancrecord:scvd-general-store-repo:x402-before-you-pay",
+  "displayName": "x402: Before You Pay",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/seancrecord/scvd-general-store-repo/blob/main/examples/claude-code/SKILL.md",
+  "description": "Before an agent pays an x402 endpoint, read its 402 terms and run scvd.store's free preflight and dry run over the same bytes; decide pay, do_not_pay or cannot_tell with every reason named.",
+  "tags": [
+    "x402",
+    "payments",
+    "preflight",
+    "agentic-commerce",
+    "verification",
+    "skill"
+  ],
+  "metadata": {
+    "sourceSet": "seancrecord/scvd-general-store-repo",
+    "repoPath": "examples/claude-code/SKILL.md"
+  }
+}


### PR DESCRIPTION
Adds three augments from [seancrecord/scvd-general-store-repo](https://github.com/seancrecord/scvd-general-store-repo) (MIT), the repository behind [scvd.store](https://scvd.store), an evidence observatory for agentic commerce: independent verification of x402 endpoints, payments and receipts.

**Entries**

| file | media type | definition |
|---|---|---|
| `scvd-general-store.json` | `application/ai-skill` | [`skills/scvd-general-store/SKILL.md`](https://github.com/seancrecord/scvd-general-store-repo/blob/main/skills/scvd-general-store/SKILL.md) — how an agent reads, verifies and buys at the store |
| `x402-before-you-pay.json` | `application/ai-skill` | [`examples/claude-code/SKILL.md`](https://github.com/seancrecord/scvd-general-store-repo/blob/main/examples/claude-code/SKILL.md) — read a 402's terms and run the free preflight before paying any x402 endpoint |
| `scvd-general-store-mcp.json` | `application/mcp-server+json` | [`store.scvd/general-store` on the official MCP registry](https://registry.modelcontextprotocol.io/v0/servers/store.scvd%2Fgeneral-store/versions/0.2.3), streamable HTTP at `https://scvd.store/mcp` |

**What a Copilot user gets from these**

- Before paying an x402 endpoint: `POST https://scvd.store/api/before-you-pay/v1` with the URL says whether a stock client would sign, which offer it would pick, and what the door's shape looks like. Free, no key.
- Conformance checks for any issuer's signed x402 offers and receipts, ours or a competitor's: `POST https://scvd.store/api/conformance/v1`. Free.
- A weekly, Bitcoin-anchored corpus of observed endpoint readiness (CC BY 4.0), per host at `/corpus/host/{host}.json`.
- A live practice counter for x402 clients with real settlement from $0.001, and paid signed audits, watches and settlement attestations from $0.004.

**What they do not do**

The skills instruct an agent to call public HTTPS endpoints and to read their answers; they declare no environment variables, no binaries and no install steps. Nothing asks for credentials, keys or wallet secrets, and nothing pays without a signed payment the agent's operator chose to make. The MCP server's `tools/list`, `initialize` and resource reads are free and unauthenticated; the `buy_*` tools answer with HTTP 402 x402 terms and settle only in band.

**Validation**

- Every URL is public; each `metadata.repoPath` exists on `main` in the named `sourceSet`.
- `python3 scripts/generate_ai_catalog.py --check` passes locally on all three files.
- The MCP entry's `version` and description repeat the registry's latest published version verbatim; a test in the source repository (`scripts/agentfinder-check.test.mjs`) refuses drift between these files and the manifests they describe.

Notes for the reviewer: the MCP entry uses the `urn:ai:registry.modelcontextprotocol.io:<namespace>:<name>` identifier shape your generator emits for feed rows, so that if GitHub's MCP feed later carries this server the generator dedupes to one row. Happy to switch it to the `urn:ai:github.com:...` shape if you prefer contributor entries uniform.