### PR TITLE
Add Emboss to catalog

### DIFF
--- a/catalog/GetEmboss-ai/emboss-mcp-server.json
+++ b/catalog/GetEmboss-ai/emboss-mcp-server.json
@@ -3,12 +3,13 @@
   "displayName": "Emboss MCP server",
   "mediaType": "application/mcp-server+json",
   "url": "https://github.com/GetEmboss-ai/emboss-claude-plugin/blob/main/server.json",
-  "description": "Remote MCP server that turns a flat PDF into a fillable form and fills it from data, from supporting documents with every answer sourced, or once per row of a spreadsheet. Hosted at https://api.getemboss.ai/mcp (Streamable HTTP, OAuth 2.1).",
+  "description": "Remote MCP server: Emboss turns any PDF form into a fillable one, fills it from data or supporting documents, reads a filled form back, and faxes the result to any fax number. Hosted at https://api.getemboss.ai/mcp (Streamable HTTP, OAuth 2.1).",
   "tags": [
     "mcp-server",
     "pdf",
     "forms",
     "documents",
+    "fax",
     "remote"
   ],
   "metadata": {

--- a/catalog/GetEmboss-ai/emboss-mcp-server.json
+++ b/catalog/GetEmboss-ai/emboss-mcp-server.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "urn:ai:github.com:GetEmboss-ai:emboss-claude-plugin:emboss-mcp-server",
+  "displayName": "Emboss MCP server",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://github.com/GetEmboss-ai/emboss-claude-plugin/blob/main/server.json",
+  "description": "Remote MCP server that turns a flat PDF into a fillable form and fills it from data, from supporting documents with every answer sourced, or once per row of a spreadsheet. Hosted at https://api.getemboss.ai/mcp (Streamable HTTP, OAuth 2.1).",
+  "tags": [
+    "mcp-server",
+    "pdf",
+    "forms",
+    "documents",
+    "remote"
+  ],
+  "metadata": {
+    "sourceSet": "GetEmboss-ai/emboss-claude-plugin",
+    "repoPath": "server.json"
+  }
+}

--- a/catalog/GetEmboss-ai/emboss.json
+++ b/catalog/GetEmboss-ai/emboss.json
@@ -1,0 +1,17 @@
+{
+  "identifier": "urn:ai:github.com:GetEmboss-ai:emboss-claude-plugin:emboss",
+  "displayName": "Emboss",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/GetEmboss-ai/emboss-claude-plugin/blob/main/skills/emboss/SKILL.md",
+  "description": "Fill PDF forms with Emboss: make a flat or scanned PDF fillable, fill it from notes, a document, or pasted text, or fill one copy for every row of a spreadsheet. Requires the Emboss MCP connector.",
+  "tags": [
+    "skill",
+    "pdf",
+    "forms",
+    "mcp-server"
+  ],
+  "metadata": {
+    "sourceSet": "GetEmboss-ai/emboss-claude-plugin",
+    "repoPath": "skills/emboss/SKILL.md"
+  }
+}

--- a/catalog/GetEmboss-ai/emboss.json
+++ b/catalog/GetEmboss-ai/emboss.json
@@ -3,11 +3,12 @@
   "displayName": "Emboss",
   "mediaType": "application/ai-skill",
   "url": "https://github.com/GetEmboss-ai/emboss-claude-plugin/blob/main/skills/emboss/SKILL.md",
-  "description": "Fill PDF forms with Emboss: make a flat or scanned PDF fillable, fill it from notes, a document, or pasted text, or fill one copy for every row of a spreadsheet. Requires the Emboss MCP connector.",
+  "description": "Fill PDF forms with Emboss: make a flat or scanned PDF fillable, fill it from notes, a document, or pasted text, fill one copy for every row of a spreadsheet, or fax the finished PDF. Requires the Emboss MCP connector.",
   "tags": [
     "skill",
     "pdf",
     "forms",
+    "fax",
     "mcp-server"
   ],
   "metadata": {


### PR DESCRIPTION
Adds Emboss under `catalog/GetEmboss-ai/`:

- `emboss.json`: the `emboss` skill (`skills/emboss/SKILL.md` in GetEmboss-ai/emboss-claude-plugin). Fill PDF forms: make a flat or scanned PDF fillable, fill it from notes, a document, or pasted text, or fill one copy per spreadsheet row. It uses the Emboss MCP connector.
- `emboss-mcp-server.json`: the Emboss remote MCP server itself (`server.json` in the same repo). Hosted at `https://api.getemboss.ai/mcp`, Streamable HTTP, OAuth 2.1 with dynamic client registration and public sign-up. Published in the official MCP registry as `io.github.edwinorange/emboss` (1.0.1, active), which GitHub's public MCP catalog has not picked up yet, hence the explicit entry. I read #20, which keeps the GitHub MCP catalog as the source of truth for registry-approved servers; this server is not in that catalog yet, so there is no local-versus-registry drift today, and I have nominated it for the GitHub MCP Registry separately. Happy to drop this file now, or once the registry record lands.

Validation: `python -m json.tool` on both files, `python3 scripts/generate_ai_catalog.py`, and `python3 scripts/generate_ai_catalog.py --check` all pass locally. The root `ai-catalog.json` is left for the workflow to regenerate, since a local regeneration also pulls in unrelated drift from the live MCP catalog feed.

Docs: https://getemboss.ai/docs/mcp-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fam8AgQ94zGZze8w4zdzdP
