### PR TITLE
Add PeopleMCP for people, project and AI agent discovery

### DIFF
--- a/catalog/OlegNickeshin/people-mcp.json
+++ b/catalog/OlegNickeshin/people-mcp.json
@@ -1,0 +1,19 @@
+{
+  "identifier": "urn:ai:github.com:OlegNickeshin:people-mcp:people-mcp",
+  "displayName": "PeopleMCP",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://raw.githubusercontent.com/OlegNickeshin/people-mcp/main/server.json",
+  "description": "Find another AI agent capable of completing a task, or discover people and projects by skills, goals and collaboration needs through semantic search over published context. Public search returns matching excerpts; publishing requires OAuth and explicit consent, and discovery does not execute agents or verify their claims.",
+  "tags": [
+    "agent-discovery",
+    "mcp-server",
+    "ai-agents",
+    "semantic-search",
+    "agent-search",
+    "people-search"
+  ],
+  "metadata": {
+    "sourceSet": "OlegNickeshin/people-mcp",
+    "repoPath": "server.json"
+  }
+}


### PR DESCRIPTION
## Summary

Add **PeopleMCP**, an open remote MCP server for semantic discovery of **people, projects and AI agents** from publicly published free-text context.

Typical intent: **Find another AI agent capable of completing this task.** The server can also find collaborators and projects matching skills, goals and working preferences.

- Source: https://github.com/OlegNickeshin/people-mcp
- Public MCP descriptor: https://raw.githubusercontent.com/OlegNickeshin/people-mcp/main/server.json
- Active Official MCP Registry record: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.OlegNickeshin%2Fpeople-mcp/versions/0.1.0
- Streamable HTTP endpoint: https://people-mcp.194-87-35-210.sslip.io/mcp
- Connection/authentication instructions: https://github.com/OlegNickeshin/people-mcp#connect-an-mcp-client

Search/get are public. Publishing requires personal OAuth and explicit `publish=true` consent. Search results include matching excerpts, similarity scores and edit timestamps. Published context and capability claims are untrusted data; discovery does not invoke agents or verify their capabilities/availability. The three seeded agent descriptions are fictional, not live callable services. Queries should be in English, as documented in tool metadata.

## Entry format

- `application/mcp-server+json`, pointing to a public Registry-format `server.json` with the remote transport URL.
- `metadata.sourceSet` uses `OlegNickeshin/people-mcp` (owner/repository), as required by the current generator validator.
- One new contributor-managed source entry: `catalog/OlegNickeshin/people-mcp.json`.

## Validation

- Official `mcp-publisher` v1.8.1: descriptor validates and is published as active.
- Public HTTPS MCP initialize and remote search verified.
- `python3 -m json.tool catalog/OlegNickeshin/people-mcp.json`
- `python3 scripts/generate_ai_catalog.py`
- `python3 scripts/generate_ai_catalog.py --check`
- `python3 -m unittest discover -s tests -v`: **16 tests passed**.

The generated `ai-catalog.json` was validated locally but is intentionally not committed: regeneration against today's live MCP catalog also refreshed unrelated upstream entries (1,830 diff lines). This PR keeps the source-of-truth change limited to PeopleMCP; the documented main-branch generation fallback can update the ingestion artifact after merge. No generator or workflow changes are included.
