### PR TITLE
Add Telegram Business MCP

### DIFF
--- a/catalog/OlegNickeshin/telegram-business-mcp.json
+++ b/catalog/OlegNickeshin/telegram-business-mcp.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "urn:ai:github.com:OlegNickeshin:telegram-business-mcp:telegram-business-mcp",
+  "displayName": "Telegram Business MCP",
+  "mediaType": "application/mcp-server+json",
+  "url": "https://raw.githubusercontent.com/OlegNickeshin/telegram-business-mcp/main/server.json",
+  "description": "Give AI agents access to an authorized Telegram archive through the official Telegram Business API: search conversations, read supported files and available voice transcripts, and optionally send approved replies. Requires the user's own HTTPS deployment and private endpoint secret; writes are off by default, live history starts at connection, and older messages require a Telegram Desktop export.",
+  "tags": [
+    "telegram",
+    "telegram-business",
+    "messaging",
+    "conversation-search",
+    "send-message",
+    "personal-context",
+    "remote-mcp",
+    "mcp-server",
+    "ai-agents",
+    "chatgpt",
+    "claude",
+    "self-hosted"
+  ],
+  "metadata": {
+    "sourceSet": "OlegNickeshin/telegram-business-mcp",
+    "repoPath": "server.json"
+  }
+}


### PR DESCRIPTION
## Summary

Add **Telegram Business MCP**, a self-hosted Streamable HTTP MCP integration that gives AI agents access to an authorized Telegram archive through the official Telegram Business API, without an MTProto user session.

Typical intent: **Find an MCP server that can search my Telegram conversations, read a document or voice transcript, and optionally send an approved reply.**

- Source: https://github.com/OlegNickeshin/telegram-business-mcp
- Public descriptor: https://raw.githubusercontent.com/OlegNickeshin/telegram-business-mcp/main/server.json
- Active Official MCP Registry record: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.OlegNickeshin%2Ftelegram-business-mcp/versions/0.1.0
- Deployment instructions: https://github.com/OlegNickeshin/telegram-business-mcp/blob/main/SETUP.md

## Self-hosted connection and safety

This is **not a shared public Telegram service**. The descriptor uses the Registry's URL template mechanism: `https://{host}/tg-mcp/{secret}`. Users deploy their own instance and supply their own hostname and private `MCP_HTTP_SECRET`. Both variables are required, the secret is marked `isSecret`, and neither has a default. No private endpoint, bot token or conversation content is published.

Search is full-text over collected/imported messages; live history starts at connection and earlier history requires an official Telegram Desktop JSON export. Attachment reads require `ALLOW_MEDIA=1`; voice transcripts require optional local transcription setup. Writes are off by default and require `ALLOW_SEND=1`; group sends appear as the bot rather than the account owner. Messages, files and transcripts are untrusted content, not instructions. Recipients and wording should be confirmed before sending.

## Entry format

- `application/mcp-server+json`, pointing to the public Registry-format descriptor.
- `metadata.sourceSet`: `OlegNickeshin/telegram-business-mcp` (owner/repository, as required by the generator).
- One new source entry: `catalog/OlegNickeshin/telegram-business-mcp.json`.

## Validation

- Official `mcp-publisher` v1.8.1 validated and published the descriptor; the record is active.
- Four repository discovery metadata tests passed; no live Telegram conversations were accessed.
- `python3 scripts/generate_ai_catalog.py`
- `python3 scripts/generate_ai_catalog.py --check`
- `python3 -m unittest discover -s tests -v`: **16 tests passed**.

The generated `ai-catalog.json` was validated locally but is not committed: regenerating against today's live upstream MCP catalog also refreshes unrelated entries (1,832 diff lines). This PR contains only the contributor-managed source-of-truth entry; the documented main-branch generation fallback can refresh the ingestion artifact after merge. No generator or workflow changes.
