### PR TITLE
Add CanMCP endpoint diagnostics skill

### DIFF
--- a/catalog/OlegNickeshin/canmcp.json
+++ b/catalog/OlegNickeshin/canmcp.json
@@ -1,0 +1,25 @@
+{
+  "identifier": "urn:ai:github.com:OlegNickeshin:canmcp:canmcp",
+  "displayName": "CanMCP",
+  "mediaType": "application/ai-skill",
+  "url": "https://raw.githubusercontent.com/OlegNickeshin/canmcp/main/skills/canmcp/SKILL.md",
+  "description": "Diagnose public remote MCP connection failures with the CanMCP Python CLI: inspect protocol, TLS and OAuth metadata, and explain ChatGPT/Claude compatibility findings without executing server tools. Requires local command execution and network access; interactive OAuth and possible client registration need user authorization, and results are local diagnostics rather than certification or a cloud-client connection test.",
+  "tags": [
+    "mcp",
+    "mcp-diagnostics",
+    "mcp-testing",
+    "compatibility-testing",
+    "oauth-debugging",
+    "cli",
+    "python",
+    "agent-skills",
+    "ai-agents",
+    "developer-tools",
+    "chatgpt",
+    "claude"
+  ],
+  "metadata": {
+    "sourceSet": "OlegNickeshin/canmcp",
+    "repoPath": "skills/canmcp/SKILL.md"
+  }
+}


### PR DESCRIPTION
## Summary

Add **CanMCP**, an agent skill for diagnosing public remote MCP endpoints with the existing local Python CLI.

Typical intent: **Diagnose why this MCP endpoint fails to connect, without executing any server tools.**

- Source: https://github.com/OlegNickeshin/canmcp
- Public skill: https://github.com/OlegNickeshin/canmcp/blob/main/skills/canmcp/SKILL.md
- Raw skill: https://raw.githubusercontent.com/OlegNickeshin/canmcp/main/skills/canmcp/SKILL.md
- Existing CLI distribution: https://pypi.org/project/canmcp/

## Scope

This entry is `application/ai-skill`, **not an MCP server**. CanMCP remains a CLI requiring command execution, Python 3.11+ and direct DNS/HTTP(S) access. There is no hosted scanner or remote connector endpoint.

The skill explains how to run a bounded scan, read JSON and nonzero exit codes, distinguish protocol failures from incomplete inspections, and preserve the scanner's public-target/TLS boundary. Normal inspection does not sign in, register clients or call server tools. Optional OAuth requires user authorization; Dynamic Client Registration may leave a provider-side registration. The browser for the loopback callback must run on the CLI machine. Results are local diagnostics, not conformance certification or proof that a particular ChatGPT/Claude account can connect.

No endpoint credentials, private targets, conversation content or tokens are published. Secret path segments require redaction before sharing reports.

## Validation

- Skill frontmatter/scaffold validation passed.
- CLI flags and installed version checked against CanMCP 0.2.0.
- Full CanMCP suite: **201 tests passed**, including scripted protocol and local TLS/OAuth fixtures.
- Ruff lint/format checks passed; sdist and wheel build succeeded. The skill is included in the source archive.
- Default CLI inspection of the owner's public PeopleMCP endpoint completed without OAuth or tool execution. Its diagnostic profiles passed; this is not a cloud-client acceptance test.
- Agent Finder tests: **16 passed**.
- `python3 scripts/generate_ai_catalog.py` and `--check` passed.

Only `catalog/OlegNickeshin/canmcp.json` is committed here. `metadata.sourceSet` is `OlegNickeshin/canmcp`, as required by the validator. Regenerating `ai-catalog.json` also changes unrelated live upstream metadata (1,844 diff lines); it was validated locally but omitted from this focused source-entry PR. The documented main-branch fallback can regenerate the ingestion artifact after merge. No generator or workflow changes.
