### PR TITLE
Add PowMCP client site handoff skill

### DIFF
--- a/catalog/powmcp/produce-client-site-handoff-report.json
+++ b/catalog/powmcp/produce-client-site-handoff-report.json
@@ -1,0 +1,12 @@
+{
+  "identifier": "urn:ai:github.com:powmcp:skills:produce-client-site-handoff-report",
+  "displayName": "PowMCP Client Site Handoff Report",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/powmcp/skills/blob/main/skills/produce-client-site-handoff-report/SKILL.md",
+  "description": "Produce a client site handoff report with observed broken-link and image-target evidence from a deployed public page. Guides the agent through checking, fixing, redeploying, and rechecking up to 100 unique targets on that page; does not claim whole-site or accessibility coverage.",
+  "tags": ["skill", "web-development", "broken-links", "deployment", "quality-assurance"],
+  "metadata": {
+    "sourceSet": "powmcp/skills",
+    "repoPath": "skills/produce-client-site-handoff-report/SKILL.md"
+  }
+}


### PR DESCRIPTION
Adds one public PowMCP skill for producing a client site handoff report with live link-integrity evidence. The skill guides checking, remediation, redeployment, and rechecking; its scope is one public page and at most 100 unique link/image targets.

The linked MIT-licensed skill is already public in powmcp/skills. Execution uses PowMCP's hosted service; the service implementation is not included in this contribution. The skill documents guest limits and current client/account-linking limitations. Copilot end-to-end execution has not been verified.

Validation: JSON parsing passed; scripts/generate_ai_catalog.py and its --check passed locally (2,108 entries). Regeneration also refreshed unrelated live MCP catalog records, so this PR includes only the contributor-managed source file and leaves generated catalog refresh to the documented upstream workflow.

Prepared with agent assistance on behalf of PowMCP.