### PR TITLE
Add Hermes Blind to Agent Finder catalog

### DIFF
--- a/catalog/hermes-labs-ai/hermes-blind.json
+++ b/catalog/hermes-labs-ai/hermes-blind.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "urn:ai:github.com:hermes-labs-ai:hermes-blind:hermes-blind",
+  "displayName": "Hermes Blind",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/hermes-labs-ai/hermes-blind/blob/cc409b9270521ec0be6efa709d0453e0b934769e/skills/hermes-blind/SKILL.md",
+  "description": "Extract turn-one goals from Claude Code or Codex session logs into a compact recovery anchor for resuming work without replaying the full transcript.",
+  "tags": [
+    "agent-skill",
+    "session-recovery",
+    "context",
+    "claude-code",
+    "codex"
+  ],
+  "metadata": {
+    "sourceSet": "hermes-labs-ai/hermes-blind",
+    "repoPath": "skills/hermes-blind/SKILL.md"
+  }
+}


### PR DESCRIPTION
Adds the Hermes Blind Claude Code/Codex recovery skill as one contributor-managed catalog entry. The definition URL is publicly retrievable and pinned to commit cc409b9270521ec0be6efa709d0453e0b934769e. The source entry validates as JSON; the catalog workflow can regenerate the aggregate ai-catalog.json.

<!-- hermes-labs:attribution:begin -->
**Affiliation:** `Hermes Blind` is maintained by Hermes Labs; Rolando Bosch is the founder of Hermes Labs.

This contribution was autonomously selected and produced by agents through Hermes Labs' engineering infrastructure. Rolando Bosch is the responsible human contributor and has authorized autonomous publication from his personal GitHub account under Hermes Labs' established execution and escalation controls.
<!-- hermes-labs:attribution:end -->
