### PR TITLE
Add YYLO Ledger Tasks skill to catalog

### DIFF
--- a/catalog/yylo-dev/ledger-tasks-yylo.json
+++ b/catalog/yylo-dev/ledger-tasks-yylo.json
@@ -1,0 +1,18 @@
+{
+  "identifier": "urn:ai:github.com:yylo-dev:yylo-skills:ledger-tasks-yylo",
+  "displayName": "YYLO Ledger Tasks",
+  "mediaType": "application/ai-skill",
+  "url": "https://github.com/yylo-dev/yylo-skills/blob/main/skills/ledger-tasks-yylo/SKILL.md",
+  "description": "Comprehensive guide for using YYLO Ledger task management. Covers all commands (create, list, search, get, mark, update, archive, deps, ready, order, merge), dependency management, best practices, and workflow patterns. Use when you need to interact with the YYLO Ledger board.",
+  "tags": [
+    "skill",
+    "task-management",
+    "kanban",
+    "cli",
+    "agents"
+  ],
+  "metadata": {
+    "sourceSet": "yylo-dev/yylo-skills",
+    "repoPath": "skills/ledger-tasks-yylo/SKILL.md"
+  }
+}


### PR DESCRIPTION
## What

Adds one augment entry to the catalog: **YYLO Ledger Tasks**, an agent skill for task management through the YYLO Ledger CLI.

- File: `catalog/yylo-dev/ledger-tasks-yylo.json` (new; publisher dir `yylo-dev` is new)
- `mediaType`: `application/ai-skill` — the entry points at the skill's `SKILL.md` definition file in its source repository
- `url` / `metadata.repoPath`: `skills/ledger-tasks-yylo/SKILL.md` on the `yylo-dev/yylo-skills` default branch
- `description` is quoted verbatim from that `SKILL.md`'s frontmatter

## Validation

- `python3 scripts/generate_ai_catalog.py` and `--check` run locally with this file added: `ai-catalog.json: 2108 entries` — no validation failures.

## About the skill / disclosure

- I'm part of the YYLO team (publisher `yylo-dev`, JUNO AI INC.) — this is a vendor-submitted entry for our own skill, affiliation disclosed up front.
- The PR was prepared with AI coding-agent assistance and reviewed by the team. Happy to rework the entry (description, tags, naming) to fit review feedback, or withdraw it if the augment is out of scope for the catalog.
- Only one augment is submitted for now; the publisher's other skills can follow separately if this one lands.
